### PR TITLE
feat: add support switching between personal and brand channel of same YT account

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/auth/YouTubeLoginRepository.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/auth/YouTubeLoginRepository.kt
@@ -165,6 +165,24 @@ class YouTubeLoginRepository
             }
         }
 
+        suspend fun updateLoginSessionChannel(
+            dataSyncId: String,
+            accountName: String,
+            accountEmail: String,
+            accountChannelHandle: String,
+        ) {
+            withContext(Dispatchers.IO) {
+                val normalizedDataSyncId = dataSyncId.normalizeDataSyncId() ?: return@withContext
+                context.dataStore.edit { preferences ->
+                    preferences[DataSyncIdKey] = normalizedDataSyncId
+                    preferences[AccountNameKey] = accountName
+                    if (accountEmail.isNotBlank()) preferences[AccountEmailKey] = accountEmail
+                    if (accountChannelHandle.isNotBlank()) preferences[AccountChannelHandleKey] = accountChannelHandle
+                }
+                YouTube.dataSyncId = normalizedDataSyncId
+            }
+        }
+
         suspend fun savePoTokens(
             gvsToken: String?,
             visitorData: String?,
@@ -302,6 +320,24 @@ class SaveYouTubePoTokensUseCase
                 visitorData = visitorData,
             )
         }
+    }
+
+class UpdateYouTubeLoginSessionChannelUseCase
+    @Inject
+    constructor(
+        private val repository: YouTubeLoginRepository,
+    ) {
+        suspend operator fun invoke(
+            dataSyncId: String,
+            accountName: String,
+            accountEmail: String,
+            accountChannelHandle: String,
+        ) = repository.updateLoginSessionChannel(
+            dataSyncId = dataSyncId,
+            accountName = accountName,
+            accountEmail = accountEmail,
+            accountChannelHandle = accountChannelHandle,
+        )
     }
 
 private suspend inline fun <T> runCatchingPreservingCancellation(crossinline block: suspend () -> T): Result<T> =

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/LoginScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/LoginScreen.kt
@@ -17,31 +17,54 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import android.widget.Toast
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SegmentedListItem
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
+import coil3.compose.AsyncImage
 import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.innertube.utils.hasYouTubeLoginCookie
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.utils.backToMain
 import moe.rukamori.archivetune.utils.resetAuthWebViewSession
+import moe.rukamori.archivetune.viewmodels.AccountChannelUiModel
 import moe.rukamori.archivetune.viewmodels.LoginScreenState
 import moe.rukamori.archivetune.viewmodels.LoginViewModel
+
 
 const val LOGIN_ROUTE = "login"
 const val LOGIN_URL_ARGUMENT = "url"
@@ -186,6 +209,98 @@ fun LoginScreen(
             webView?.goBack()
         } else {
             onNavigateBack?.invoke()
+        }
+    }
+
+    if (screenState is LoginScreenState.ChannelSelection) {
+        val channels = (screenState as LoginScreenState.ChannelSelection).channels
+        ModalBottomSheet(onDismissRequest = { /* Cannot dismiss without selection here */ }) {
+            Text(
+                text = stringResource(R.string.youtube_channels),
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp),
+            )
+            LazyColumn(
+                modifier = Modifier.fillMaxWidth().heightIn(max = 600.dp),
+                contentPadding = PaddingValues(start = 16.dp, top = 8.dp, end = 16.dp, bottom = 32.dp),
+                verticalArrangement = Arrangement.spacedBy(ListItemDefaults.SegmentedGap),
+            ) {
+                itemsIndexed(
+                    items = channels,
+                    key = { index, channel -> "${channel.dataSyncId}:${channel.name}:$index" },
+                    contentType = { _, _ -> "channel" },
+                ) { index, channel ->
+                    SegmentedListItem(
+                        selected = channel.isSelected,
+                        onClick = { viewModel.selectChannel(channel) },
+                        modifier = Modifier.fillMaxWidth(),
+                        shapes = ListItemDefaults.segmentedShapes(index = index, count = channels.size),
+                        colors = ListItemDefaults.segmentedColors(containerColor = MaterialTheme.colorScheme.surfaceContainer),
+                        leadingContent = {
+                            LoginChannelAvatar(
+                                imageUrl = channel.thumbnailUrl,
+                                fallbackIcon = painterResource(R.drawable.account),
+                            )
+                        },
+                        trailingContent = {
+                            if (channel.isSelected) {
+                                Icon(
+                                    painter = painterResource(R.drawable.check),
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.primary,
+                                )
+                            }
+                        },
+                        supportingContent = {
+                            val subtitle = channel.channelHandle.ifBlank { channel.byline }
+                            if (subtitle.isNotBlank()) {
+                                Text(
+                                    text = subtitle,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+                            }
+                        },
+                    ) {
+                        Text(
+                            text = channel.name,
+                            fontWeight = if (channel.isSelected) FontWeight.SemiBold else FontWeight.Normal,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun LoginChannelAvatar(
+    imageUrl: String?,
+    fallbackIcon: Painter,
+) {
+    Surface(
+        modifier = Modifier.size(72.dp),
+        shape = MaterialTheme.shapes.medium,
+        color = MaterialTheme.colorScheme.secondaryContainer,
+    ) {
+        if (imageUrl != null) {
+            AsyncImage(
+                model = imageUrl,
+                contentDescription = null,
+                modifier = Modifier.fillMaxSize(),
+            )
+        } else {
+            Box(contentAlignment = Alignment.Center) {
+                Icon(
+                    painter = fallbackIcon,
+                    contentDescription = null,
+                    modifier = Modifier.size(20.dp),
+                    tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                )
+            }
         }
     }
 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/viewmodels/LoginViewModel.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/viewmodels/LoginViewModel.kt
@@ -22,7 +22,9 @@ import moe.rukamori.archivetune.auth.GenerateYouTubePoTokensUseCase
 import moe.rukamori.archivetune.auth.MissingYouTubeDataSyncIdException
 import moe.rukamori.archivetune.auth.SaveYouTubePoTokensUseCase
 import moe.rukamori.archivetune.auth.UpdateYouTubeLoginContextUseCase
+import moe.rukamori.archivetune.auth.UpdateYouTubeLoginSessionChannelUseCase
 import moe.rukamori.archivetune.innertube.PlaybackAuthState
+import moe.rukamori.archivetune.innertube.YouTube
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -31,6 +33,10 @@ sealed interface LoginScreenState {
 
     data class Success(
         val account: LoginAccountUiModel,
+    ) : LoginScreenState
+
+    data class ChannelSelection(
+        val channels: List<AccountChannelUiModel>,
     ) : LoginScreenState
 
     data object Empty : LoginScreenState
@@ -61,6 +67,7 @@ class LoginViewModel
         private val updateYouTubeLoginContext: UpdateYouTubeLoginContextUseCase,
         private val generateYouTubePoTokens: GenerateYouTubePoTokensUseCase,
         private val saveYouTubePoTokens: SaveYouTubePoTokensUseCase,
+        private val updateYouTubeLoginSessionChannel: UpdateYouTubeLoginSessionChannelUseCase,
     ) : ViewModel() {
         private val _screenState = MutableStateFlow<LoginScreenState>(LoginScreenState.Empty)
         val screenState: StateFlow<LoginScreenState> = _screenState.asStateFlow()
@@ -131,15 +138,30 @@ class LoginViewModel
                             sessionId = session.authState.sessionId,
                             visitorData = session.authState.visitorData,
                         )
-                        _screenState.value =
-                            LoginScreenState.Success(
-                                LoginAccountUiModel(
-                                    name = session.accountName,
-                                    email = session.accountEmail,
-                                    channelHandle = session.accountChannelHandle,
-                                    dataSyncId = session.authState.dataSyncId.orEmpty(),
-                                ),
+                        val accountChannels = YouTube.accountChannels().getOrNull()?.map { channel ->
+                            AccountChannelUiModel(
+                                name = channel.name,
+                                byline = channel.byline.orEmpty(),
+                                channelHandle = channel.channelHandle.orEmpty(),
+                                thumbnailUrl = channel.thumbnailUrl.orEmpty(),
+                                dataSyncId = channel.dataSyncId,
+                                isSelected = channel.isSelected,
                             )
+                        }?.takeIf { it.size > 1 }
+
+                        if (accountChannels != null) {
+                            _screenState.value = LoginScreenState.ChannelSelection(accountChannels)
+                        } else {
+                            _screenState.value =
+                                LoginScreenState.Success(
+                                    LoginAccountUiModel(
+                                        name = session.accountName,
+                                        email = session.accountEmail,
+                                        channelHandle = session.accountChannelHandle,
+                                        dataSyncId = session.authState.dataSyncId.orEmpty(),
+                                    ),
+                                )
+                        }
                     }.onFailure { throwable ->
                         Timber.e(throwable, "Failed to complete YouTube login")
                         _screenState.value =
@@ -152,6 +174,26 @@ class LoginViewModel
                             )
                     }
                 }
+        }
+
+        fun selectChannel(channel: AccountChannelUiModel) {
+            viewModelScope.launch {
+                updateYouTubeLoginSessionChannel(
+                    dataSyncId = channel.dataSyncId,
+                    accountName = channel.name,
+                    accountEmail = channel.byline,
+                    accountChannelHandle = channel.channelHandle,
+                )
+                _screenState.value =
+                    LoginScreenState.Success(
+                        LoginAccountUiModel(
+                            name = channel.name,
+                            email = channel.byline,
+                            channelHandle = channel.channelHandle,
+                            dataSyncId = channel.dataSyncId,
+                        ),
+                    )
+            }
         }
 
         private suspend fun persistPoTokens(


### PR DESCRIPTION
# Pull Request

Before submitting a pull request, you must attest to the following:

- [X] This pull request complies with ArchiveTune's [NO AI / NO LLM POLICY](../CONTRIBUTING.md#no-ai--no-llm-policy).

## Summary

I added the feature to switch between personal channels and brand channels in the account settings. Useful for people (like me) , who have their playlists on the brand channel.

## Change Type

<!-- Check every category that applies. -->

- [X] Feature
- [ ] Bug fix
- [X] UI / UX
- [ ] Performance / memory
- [ ] Playback / Media3
- [ ] Lyrics / provider integration
- [X] Search / YouTube / network data
- [ ] Local library / Room database
- [ ] Widgets / notification / shortcuts
- [X] Settings / preferences / DataStore
- [ ] Discord / Last.fm / ListenBrainz / external integration
- [ ] Localization / strings / fastlane metadata
- [ ] Build / Gradle / CI / release packaging
- [ ] Dependency update
- [ ] Documentation only

## Affected Surfaces

<!-- Be explicit so reviewers can focus on the correct runtime paths. -->

- [X] `:app`
- [X] `:core`
- [ ] `:lyrics`
- [ ] `:lastfm`
- [ ] `:canvas`
- [ ] `:shazamkit`
- [ ] `:spotifycore`
- [ ] Other:

## Screenshots / Recordings

<!-- Required for UI, widget, notification, player, lyrics, settings, and visual changes. Include before/after when possible. -->

| Before | After |
| --- | --- |
|<img src="https://github.com/user-attachments/assets/aa2d9332-516a-4659-be9e-ad29226a5acf" width="200" />| <img src="https://github.com/user-attachments/assets/e02cd965-595d-41c9-9ac6-af153759094e" width="200" />|

## Behavior Notes

When a user logs in with an account that has both a personal channel and a brand channel, the app now properly intercepts the login flow and lets the user pick which channel to use.

In Settings, Account opening the account switcher will now accurately list both the personal channel and any brand channels associated with the active session, allowing users to switch between them on the fly.

## Architecture Checklist

- [X] The change preserves UDF flow: UI -> ViewModel -> UseCase/domain -> Repository/data.
- [X] Screen state is represented structurally with `Loading`, `Success`, `Empty`, and `Error` where this PR introduces or changes screen state.
- [X] Composables receive immutable, UI-specific domain models instead of raw Room, network, or service entities.
- [X] Business work is not triggered directly from composition.
- [X] Exceptions are surfaced through explicit state or result types instead of being swallowed.
- [X] No `runBlocking` is introduced in app execution paths.

## Compose / Material Checklist

- [X] UI state is hoisted out of composable layout code.
- [X] Reactive state is collected with `collectAsStateWithLifecycle()`.
- [ ] New UI models are annotated with `@Immutable` or `@Stable`.
- [X] Lazy layouts use stable `key` values and explicit `contentType`.
- [ ] Non-primitive constants, structural lambdas, and allocation-heavy objects in hot paths are remembered.
- [ ] Rapidly changing inputs such as scroll, gesture, animation, or playback progress use `derivedStateOf` where appropriate.
- [X] UI strings come from `stringResource()` and duplicated visible strings on the same screen are avoided.
- [X] Interactive elements keep a minimum 48dp touch target.
- [X] Material 3 / Material 3 Expressive tokens are used for color, typography, shape, and motion instead of hardcoded UI values.
- [ ] Edge-to-edge layouts handle and consume `WindowInsets` correctly when this PR changes screen layout.

## Concurrency / Performance Checklist

- [X] Business coroutines are scoped to `viewModelScope` or an existing lifecycle-owned application/service scope.
- [X] Disk, database, network, parsing, and heavy mapping work is dispatched to `Dispatchers.IO` or `Dispatchers.Default`.
- [X] Cancellation is handled explicitly where long-running work, playback, downloads, sync, lyrics fetching, or recognition is involved.
- [X] The change avoids blocking the main thread.
- [X] The change avoids unnecessary allocations in recomposition loops, playback loops, polling loops, and provider parsing paths.
- [X] Large lists, images, lyrics payloads, and network responses are bounded, streamed, cached, paged, or mapped off the main thread as appropriate.

## Data / Persistence Checklist

- [ ] Room entity, DAO, or database changes include a schema update under `app/schemas`.
- [ ] Database migrations preserve existing user data and fail clearly when migration is impossible.
- [X] DataStore or preference-key changes are backward compatible.
- [X] Network DTOs remain isolated from UI models.
- [X] Provider responses handle missing, malformed, regional, or rate-limited data without crashing the app.

## Playback / Integration Checklist

- [ ] Media3 playback, queue, cache, and service behavior remains stable across foreground, background, notification, and process recreation paths.
- [ ] Audio focus, notification controls, widgets, shortcuts, and media session actions are considered when playback behavior changes.
- [X] External integrations handle absent credentials, revoked auth, network failure, and API changes.
- [ ] Native, AAR, or ABI-sensitive changes account for mobile/tv and `universal`, `arm64`, `armeabi`, `x86`, and `x86_64` variants.

## Localization / Assets Checklist

- [ ] User-facing strings are added to the base resources and translated resources are updated or intentionally left for translation follow-up.
- [ ] Unused string resources, drawables, and metadata are removed when replaced.
- [ ] Image assets have explicit display dimensions and are decoded at the displayed size.
- [ ] Fastlane metadata, screenshots, icons, or release text are updated when user-facing store behavior changes.

## Privacy / Security Checklist

- [X] No secrets, keys, tokens, keystores, signing files, private certificates, or local machine paths are committed.
- [X] Logs do not expose access tokens, cookies, auth headers, user identifiers, listening history, or local file paths.
- [X] New network calls are justified by the feature and use existing client, proxy, timeout, and error-handling patterns.
- [X] User data remains local unless the PR explicitly documents the integration and consent path.

## Verification

- [X] Android Studio sync: Gradle syncs successfully
- [X] Manual device/emulator verification: successfully tested the login flow on my own physical device.
- [X] UI screenshot/recording attached: see above
- [ ] Accessibility or touch-target review: relies on existing SegmentedListItem. no review needed
- [X] Regression areas checked: done
- [X] CI expectation: local build suceeds without any errors. expected CI to pass cleanly.

## Reviewer Focus

Only works with changes to `core/.../innertube/YouTube.kt`. Seperate pull request will be created after this.

## Release Notes

Added the ability to seamlessly switch between personal and brand channels from the account settings screen.
