### PR TITLE
feat(player): Introduce V10 Editorial Player, V9 color extraction fixes, and player enhancements

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -311,6 +311,7 @@ dependencies {
     implementation(libs.lifecycle.runtime.compose)
 
     implementation(libs.material3)
+    implementation(libs.androidx.graphics.shapes)
     implementation(libs.palette)
     implementation(libs.androidsvg)
     implementation(libs.aboutlibraries.core)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -1164,7 +1164,8 @@ class MainActivity : ComponentActivity() {
 
                     val shouldHideStatusBars =
                         isYearInMusicScreen ||
-                            (playerBottomSheetState.isExpandedOrExpanding && playerDesignStyle == PlayerDesignStyle.V7)
+                            (playerBottomSheetState.isExpandedOrExpanding &&
+                                playerDesignStyle == PlayerDesignStyle.V7)
 
                     LaunchedEffect(shouldHideStatusBars, aodModeEnabled) {
                         if (aodModeEnabled) return@LaunchedEffect

--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -381,7 +381,7 @@ class MainActivity : ComponentActivity() {
     }
 
     private fun requestAodMode() {
-        if (!dataStore.get(AodModeEnabledKey, true)) return
+        if (!dataStore.get(AodModeEnabledKey, false)) return
         pendingAodModeRequest = true
         startMusicServiceSafely()
         openPendingAodModeIfReady()

--- a/app/src/main/kotlin/moe/rukamori/archivetune/aod/AodDreamService.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/aod/AodDreamService.kt
@@ -100,7 +100,7 @@ class AodDreamService :
         lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_START)
         lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
 
-        if (!dataStore.get(AodModeEnabledKey, true)) {
+        if (!dataStore.get(AodModeEnabledKey, false)) {
             finish()
             return
         }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
@@ -663,6 +663,7 @@ enum class PlayerDesignStyle {
     V7,
     V8,
     V9,
+    V10,
 }
 
 enum class PlayerBackgroundStyle {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
@@ -1194,7 +1194,7 @@ class MusicService :
                 if (intent?.action != Intent.ACTION_SCREEN_OFF) return
                 scope.launch {
                     val preferences = dataStore.data.first()
-                    val aodEnabled = preferences[AodModeEnabledKey] ?: true
+                    val aodEnabled = preferences[AodModeEnabledKey] ?: false
                     val autoStartAod = preferences[AodAutoStartScreenOffKey] ?: true
                     if (!aodEnabled || !autoStartAod || !player.isPlaying) return@launch
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/PlayerMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/PlayerMenu.kt
@@ -90,6 +90,7 @@ import moe.rukamori.archivetune.LocalDownloadUtil
 import moe.rukamori.archivetune.LocalPlayerConnection
 import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.constants.ArchiveTuneCanvasKey
+import moe.rukamori.archivetune.constants.AodModeEnabledKey
 import moe.rukamori.archivetune.constants.ArtistSeparatorsKey
 import moe.rukamori.archivetune.constants.ExternalDownloaderEnabledKey
 import moe.rukamori.archivetune.constants.ExternalDownloaderPackageKey
@@ -160,6 +161,7 @@ fun PlayerMenu(
     // Artist separators for splitting artist names
     val (artistSeparators) = rememberPreference(ArtistSeparatorsKey, defaultValue = ",;/&")
     val (externalDownloaderEnabled) = rememberPreference(ExternalDownloaderEnabledKey, defaultValue = false)
+    val (aodFeatureEnabled, onAodFeatureEnabledChange) = rememberPreference(AodModeEnabledKey, defaultValue = false)
     val (externalDownloaderPackage) = rememberPreference(ExternalDownloaderPackageKey, defaultValue = "")
     val (archiveTuneCanvasEnabled) = rememberPreference(ArchiveTuneCanvasKey, defaultValue = false)
     val playerDesignStyle by rememberEnumPreference(PlayerDesignStyleKey, defaultValue = PlayerDesignStyle.V4)
@@ -616,6 +618,8 @@ fun PlayerMenu(
                                 )
                             }
                             if (isQueueTrigger != true) {
+                                val aodBgColor = if (aodFeatureEnabled) MaterialTheme.colorScheme.primary else Color.Unspecified
+                                val aodContentColor = if (aodFeatureEnabled) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurfaceVariant
                                 add(
                                     NewAction(
                                         icon = {
@@ -623,14 +627,15 @@ fun PlayerMenu(
                                                 painter = painterResource(R.drawable.bedtime),
                                                 contentDescription = null,
                                                 modifier = Modifier.size(28.dp),
-                                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                                tint = aodContentColor,
                                             )
                                         },
                                         text = stringResource(R.string.aod_mode),
                                         onClick = {
-                                            playerConnection.aodModeEnabled.value = true
-                                            onDismiss()
+                                            onAodFeatureEnabledChange(!aodFeatureEnabled)
                                         },
+                                        backgroundColor = aodBgColor,
+                                        contentColor = aodContentColor,
                                     ),
                                 )
                             }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
@@ -1675,16 +1675,6 @@ fun BottomSheetPlayer(
                                             WindowInsetsSides.Top + WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom,
                                         ),
                                     )
-                                    .pointerInput(Unit) {
-                                        detectDragGestures { change, dragAmount ->
-                                            change.consume()
-                                            if (dragAmount.y > 15) {
-                                                state.collapseSoft()
-                                            } else if (dragAmount.y < -15) {
-                                                openQueue()
-                                            }
-                                        }
-                                    }
                                     .nestedScroll(state.preUpPostDownNestedScrollConnection),
                         )
                     }
@@ -2022,16 +2012,6 @@ fun BottomSheetPlayer(
                                             WindowInsetsSides.Top + WindowInsetsSides.Horizontal,
                                         ),
                                     )
-                                    .pointerInput(Unit) {
-                                        detectDragGestures { change, dragAmount ->
-                                            change.consume()
-                                            if (dragAmount.y > 15) {
-                                                state.collapseSoft()
-                                            } else if (dragAmount.y < -15) {
-                                                openQueue()
-                                            }
-                                        }
-                                    }
                                     .nestedScroll(state.preUpPostDownNestedScrollConnection),
                         )
                     }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
@@ -102,6 +102,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.input.key.Key
@@ -191,11 +192,18 @@ import moe.rukamori.archivetune.ui.component.BottomSheetState
 import moe.rukamori.archivetune.ui.component.LocalBottomSheetPageState
 import moe.rukamori.archivetune.ui.component.LocalMenuState
 import moe.rukamori.archivetune.ui.component.rememberBottomSheetState
+import moe.rukamori.archivetune.ui.menu.AddToPlaylistDialog
 import moe.rukamori.archivetune.ui.menu.PlayerMenu
 import moe.rukamori.archivetune.ui.screens.LOGIN_ROUTE
 import moe.rukamori.archivetune.ui.screens.buildLoginRoute
 import moe.rukamori.archivetune.ui.screens.settings.DarkMode
 import moe.rukamori.archivetune.ui.theme.PlayerColorExtractor
+import android.widget.Toast
+import androidx.compose.foundation.gestures.detectDragGestures
+import com.materialkolor.hct.Hct
+import com.materialkolor.ktx.toHct
+import com.materialkolor.ktx.toColor
+import moe.rukamori.archivetune.ui.utils.highRes
 import moe.rukamori.archivetune.ui.utils.ShowMediaInfo
 import moe.rukamori.archivetune.ui.utils.YtimgResizePolicy
 import moe.rukamori.archivetune.ui.utils.getNextFallbackUrl
@@ -357,7 +365,7 @@ fun BottomSheetPlayer(
         defaultValue = PlayerBackgroundStyle.DEFAULT,
     )
     val playerUsesFixedBackground =
-        playerDesignStyle == PlayerDesignStyle.V8 || playerDesignStyle == PlayerDesignStyle.V9
+        playerDesignStyle == PlayerDesignStyle.V8 || playerDesignStyle == PlayerDesignStyle.V9 || playerDesignStyle == PlayerDesignStyle.V10
     val playerBackground =
         if (playerUsesFixedBackground) PlayerBackgroundStyle.DEFAULT else storedPlayerBackground
 
@@ -447,6 +455,13 @@ fun BottomSheetPlayer(
     val (thumbnailCornerRadius) = rememberPreference(ThumbnailCornerRadiusKey, defaultValue = 8f)
     val archiveTuneCanvasEnabled by rememberPreference(ArchiveTuneCanvasKey, false)
     val lowDataModeActive = rememberLowDataModeActive()
+    val playerSwapState =
+        rememberThumbnailSwapState(
+            videoId = mediaMetadata?.id,
+            ytmUrl = mediaMetadata?.thumbnailUrl?.highRes(),
+            lowDataMode = lowDataModeActive,
+            isMusicVideo = mediaMetadata?.isMusicVideo ?: false,
+        )
     val (maxCanvasCacheSize, _) =
         rememberPreference(
             key = MaxCanvasCacheSizeKey,
@@ -482,6 +497,12 @@ fun BottomSheetPlayer(
         mutableStateOf<List<Color>>(emptyList())
     }
 
+    // Exact seeds from artwork color scheme
+    var v10ArtworkSeeds by remember {
+        mutableStateOf<Pair<Color, Color>?>(null)
+    }
+    val v10ArtworkSeedsCache = remember { mutableMapOf<String, Pair<Color, Color>>() }
+
     // Previous background states for smooth transitions
     var previousThumbnailUrl by remember { mutableStateOf<String?>(null) }
     var previousGradientColors by remember { mutableStateOf<List<Color>>(emptyList()) }
@@ -502,27 +523,30 @@ fun BottomSheetPlayer(
         }
     }
 
-    LaunchedEffect(mediaMetadata?.id, mediaMetadata?.thumbnailUrl, playerBackground, playerDesignStyle) {
+    LaunchedEffect(mediaMetadata?.id, playerSwapState.displayUrl, playerBackground, playerDesignStyle) {
         if (aodModeEnabled) return@LaunchedEffect
-        if (playerDesignStyle == PlayerDesignStyle.V9 ||
+        if (playerDesignStyle == PlayerDesignStyle.V9 || playerDesignStyle == PlayerDesignStyle.V10 ||
             playerBackground == PlayerBackgroundStyle.GRADIENT || playerBackground == PlayerBackgroundStyle.COLORING ||
             playerBackground == PlayerBackgroundStyle.BLUR_GRADIENT ||
             playerBackground == PlayerBackgroundStyle.GLOW ||
             playerBackground == PlayerBackgroundStyle.GLOW_ANIMATED
         ) {
             val currentMetadata = mediaMetadata
-            if (currentMetadata != null && currentMetadata.thumbnailUrl != null) {
+            val displayThumbnail = playerSwapState.displayUrl
+            if (currentMetadata != null && displayThumbnail != null) {
                 // Check cache first
                 val cachedColors = gradientColorsCache[currentMetadata.id]
-                if (cachedColors != null) {
+                val cachedV10Seeds = v10ArtworkSeedsCache[currentMetadata.id]
+                if (cachedColors != null && cachedV10Seeds != null) {
                     gradientColors = cachedColors
+                    v10ArtworkSeeds = cachedV10Seeds
                 } else {
                     val request =
                         ImageRequest
                             .Builder(context)
-                            .data(currentMetadata.thumbnailUrl)
-                            .memoryCacheKey(currentMetadata.thumbnailUrl)
-                            .diskCacheKey(currentMetadata.thumbnailUrl)
+                            .data(displayThumbnail)
+                            .memoryCacheKey(displayThumbnail)
+                            .diskCacheKey(displayThumbnail)
                             .diskCachePolicy(CachePolicy.ENABLED)
                             .networkCachePolicy(CachePolicy.ENABLED)
                             .size(PlayerColorExtractor.Config.IMAGE_SIZE, PlayerColorExtractor.Config.IMAGE_SIZE)
@@ -554,8 +578,28 @@ fun BottomSheetPlayer(
                                     fallbackColor = fallbackColor,
                                 )
 
+                            // EXACT artwork seeds extraction
+                            val primarySeed = palette.vibrantSwatch
+                                ?: palette.lightVibrantSwatch
+                                ?: palette.darkVibrantSwatch
+                                ?: palette.dominantSwatch
+                            val secondarySeed = palette.mutedSwatch
+                                ?: palette.lightMutedSwatch
+                                ?: palette.darkMutedSwatch
+                                ?: primarySeed
+
+                            val seeds = if (primarySeed != null && secondarySeed != null) {
+                                Pair(Color(primarySeed.rgb), Color(secondarySeed.rgb))
+                            } else {
+                                null
+                            }
+
                             gradientColorsCache[currentMetadata.id] = extractedColors
                             gradientColors = extractedColors
+                            if (seeds != null) {
+                                v10ArtworkSeedsCache[currentMetadata.id] = seeds
+                                v10ArtworkSeeds = seeds
+                            }
                         } else {
                             gradientColors = defaultGradientColors
                         }
@@ -564,7 +608,7 @@ fun BottomSheetPlayer(
                     }
                 }
             } else {
-                gradientColors = emptyList()
+                gradientColors = defaultGradientColors
             }
         } else {
             gradientColors = emptyList()
@@ -599,6 +643,51 @@ fun BottomSheetPlayer(
         label = "dynamicAccentColor"
     )
 
+    // EXACT artwork accents using HCT (Hue-Chroma-Tone) for correct toning
+    val targetV10FieldColor = remember(v10ArtworkSeeds, useDarkTheme) {
+        val seeds = v10ArtworkSeeds
+        if (seeds == null) {
+            dominantColor
+        } else {
+            val hct = seeds.first.toHct()
+            if (useDarkTheme) {
+                // primaryContainer = primarySeed tone 30
+                hct.withTone(30.0).toColor()
+            } else {
+                // primaryContainer = primarySeed tone 90
+                hct.withTone(90.0).toColor()
+            }
+        }
+    }
+
+    val dynamicV10FieldColor by animateColorAsState(
+        targetValue = targetV10FieldColor,
+        animationSpec = tween(durationMillis = 800),
+        label = "dynamicV10FieldColor"
+    )
+
+    val targetV10AccentColor = remember(v10ArtworkSeeds, useDarkTheme) {
+        val seeds = v10ArtworkSeeds
+        if (seeds == null) {
+            dominantColor
+        } else {
+            val hct = seeds.first.toHct()
+            if (useDarkTheme) {
+                // onPrimaryContainer = primarySeed tone 90
+                hct.withTone(90.0).toColor()
+            } else {
+                // onPrimaryContainer = primarySeed tone 10
+                hct.withTone(10.0).toColor()
+            }
+        }
+    }
+
+    val dynamicV10AccentColor by animateColorAsState(
+        targetValue = targetV10AccentColor,
+        animationSpec = tween(durationMillis = 800),
+        label = "dynamicV10AccentColor"
+    )
+
     val targetTextColor = remember(dominantColor, useDarkTheme) {
         val hsv = FloatArray(3)
         android.graphics.Color.colorToHSV(dominantColor.toArgb(), hsv)
@@ -628,7 +717,7 @@ fun BottomSheetPlayer(
     )
 
     val TextBackgroundColor =
-        if (playerDesignStyle == PlayerDesignStyle.V9) {
+        if (playerDesignStyle == PlayerDesignStyle.V9 || playerDesignStyle == PlayerDesignStyle.V10) {
             dynamicTextColor
         } else if (playerDesignStyle == PlayerDesignStyle.V7 || playerDesignStyle == PlayerDesignStyle.V8) {
             Color.White
@@ -646,7 +735,7 @@ fun BottomSheetPlayer(
         }
 
     val icBackgroundColor =
-        if (playerDesignStyle == PlayerDesignStyle.V9) {
+        if (playerDesignStyle == PlayerDesignStyle.V9 || playerDesignStyle == PlayerDesignStyle.V10) {
             dynamicBgColor
         } else if (playerDesignStyle == PlayerDesignStyle.V7 || playerDesignStyle == PlayerDesignStyle.V8) {
             Color.Black
@@ -727,70 +816,42 @@ fun BottomSheetPlayer(
         mutableFloatStateOf(30f)
     }
     if (showSleepTimerDialog) {
-        AlertDialog(
-            properties = DialogProperties(usePlatformDefaultWidth = false),
-            onDismissRequest = { showSleepTimerDialog = false },
-            icon = {
-                Icon(
-                    painter = painterResource(R.drawable.bedtime),
-                    contentDescription = null,
-                )
+        SleepTimerDialog(
+            onDismiss = { showSleepTimerDialog = false },
+            onConfirm = { mins ->
+                showSleepTimerDialog = false
+                sleepTimerValue = mins.toFloat()
+                playerConnection.service.sleepTimer.start(mins)
             },
-            title = { Text(stringResource(R.string.sleep_timer)) },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        showSleepTimerDialog = false
-                        playerConnection.service.sleepTimer.start(sleepTimerValue.roundToInt())
-                    },
-                    shapes = ButtonDefaults.shapes(),
-                ) {
-                    Text(stringResource(android.R.string.ok))
-                }
+            onEndOfSong = {
+                showSleepTimerDialog = false
+                playerConnection.service.sleepTimer.start(-1)
             },
-            dismissButton = {
-                TextButton(
-                    onClick = { showSleepTimerDialog = false },
-                    shapes = ButtonDefaults.shapes(),
-                ) {
-                    Text(stringResource(android.R.string.cancel))
-                }
-            },
-            text = {
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    Text(
-                        text =
-                            pluralStringResource(
-                                R.plurals.minute,
-                                sleepTimerValue.roundToInt(),
-                                sleepTimerValue.roundToInt(),
-                            ),
-                        style = MaterialTheme.typography.bodyLarge,
-                    )
-
-                    Slider(
-                        value = sleepTimerValue,
-                        onValueChange = { sleepTimerValue = it },
-                        valueRange = 5f..120f,
-                        steps = (120 - 5) / 5 - 1,
-                    )
-
-                    OutlinedIconButton(
-                        onClick = {
-                            showSleepTimerDialog = false
-                            playerConnection.service.sleepTimer.start(-1)
-                        },
-                    ) {
-                        Text(stringResource(R.string.end_of_song))
-                    }
-                }
-            },
+            initialValue = sleepTimerValue
         )
     }
 
     var showChoosePlaylistDialog by rememberSaveable {
         mutableStateOf(false)
     }
+
+    AddToPlaylistDialog(
+        isVisible = showChoosePlaylistDialog,
+        onGetSong = {
+            mediaMetadata?.let { listOf(it.id) } ?: emptyList()
+        },
+        onDismiss = { showChoosePlaylistDialog = false },
+        onAddComplete = { songCount, playlistNames ->
+            val message =
+                if (songCount == 1 && playlistNames.size == 1) {
+                    context.getString(R.string.added_to_playlist, playlistNames.first())
+                } else {
+                    context.getString(R.string.added_to_n_playlists, playlistNames.size)
+                }
+            Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+            showChoosePlaylistDialog = false
+        },
+    )
 
     LaunchedEffect(mediaMetadata?.id, playbackState, aodModeEnabled) {
         val startTime = SystemClock.elapsedRealtime()
@@ -850,7 +911,7 @@ fun BottomSheetPlayer(
     }
 
     val dynamicQueuePeekHeight =
-        if (playerDesignStyle == PlayerDesignStyle.V5) {
+        if (playerDesignStyle == PlayerDesignStyle.V5 || playerDesignStyle == PlayerDesignStyle.V10) {
             0.dp
         } else if (playerDesignStyle == PlayerDesignStyle.V9) {
             88.dp +
@@ -1008,6 +1069,17 @@ fun BottomSheetPlayer(
                         0f
                     }
                 dynamicBgColor.copy(alpha = 1f - fadeProgress)
+            } else if (playerDesignStyle == PlayerDesignStyle.V10) {
+                val progress =
+                    ((state.value - state.collapsedBound) / (state.expandedBound - state.collapsedBound))
+                        .coerceIn(0f, 1f)
+                val fadeProgress =
+                    if (progress < 0.2f) {
+                        ((0.2f - progress) / 0.2f).coerceIn(0f, 1f)
+                    } else {
+                        0f
+                    }
+                dynamicV10FieldColor.copy(alpha = 1f - fadeProgress)
             } else if (playerDesignStyle == PlayerDesignStyle.V7 || playerDesignStyle == PlayerDesignStyle.V8) {
                 val progress =
                     ((state.value - state.collapsedBound) / (state.expandedBound - state.collapsedBound))
@@ -1287,7 +1359,8 @@ fun BottomSheetPlayer(
             playerDesignStyle != PlayerDesignStyle.V5 &&
             playerDesignStyle != PlayerDesignStyle.V7 &&
             playerDesignStyle != PlayerDesignStyle.V8 &&
-            playerDesignStyle != PlayerDesignStyle.V9
+            playerDesignStyle != PlayerDesignStyle.V9 &&
+            playerDesignStyle != PlayerDesignStyle.V10
         ) {
             PlayerBackground(
                 playerBackground = playerBackground,
@@ -1540,6 +1613,79 @@ fun BottomSheetPlayer(
                                             WindowInsetsSides.Top + WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom,
                                         ),
                                     ).nestedScroll(state.preUpPostDownNestedScrollConnection),
+                        )
+                    }
+                } else if (playerDesignStyle == PlayerDesignStyle.V10) {
+                    enrichedMetadata?.let { metadata ->
+                        V10PlayerContent(
+                            mediaMetadata = metadata,
+                            playbackState = playbackState,
+                            isPlaying = isPlaying,
+                            isLoading = isLoading,
+                            canSkipPrevious = canSkipPrevious,
+                            canSkipNext = canSkipNext,
+                            sliderPosition = sliderPosition,
+                            position = position,
+                            duration = duration,
+                            playerConnection = playerConnection,
+                            navController = navController,
+                            state = state,
+                            textBackgroundColor = dynamicV10AccentColor,
+                            textButtonColor = dynamicV10FieldColor,
+                            iconButtonColor = iconButtonColor,
+                            onCollapseClick = { state.collapseSoft() },
+                            onQueueClick = openQueue,
+                            onLyricsClick = { isLyricsScreenVisible = true },
+                            onSliderValueChange = onSliderValueChange,
+                            onSliderValueChangeFinished = onSliderValueChangeFinished,
+                            onSleepTimerClick = {
+                                if (sleepTimerEnabled) {
+                                    playerConnection.service.sleepTimer.clear()
+                                } else {
+                                    showSleepTimerDialog = true
+                                }
+                            },
+                            sleepTimerEnabled = sleepTimerEnabled,
+                            sleepTimerTimeLeft = sleepTimerTimeLeft,
+                            onMenuClick = {
+                                menuState.show {
+                                    PlayerMenu(
+                                        mediaMetadata = metadata,
+                                        navController = navController,
+                                        playerBottomSheetState = state,
+                                        onShowDetailsDialog = {
+                                            bottomSheetPageState.show {
+                                                ShowMediaInfo(metadata.id)
+                                            }
+                                        },
+                                        onDismiss = menuState::dismiss,
+                                    )
+                                }
+                            },
+                            onAddToPlaylistClick = {
+                                showChoosePlaylistDialog = true
+                            },
+                            landscape = true,
+                            modifier =
+                                Modifier
+                                    .fillMaxSize()
+                                    .padding(bottom = queueSheetState.collapsedBound)
+                                    .windowInsetsPadding(
+                                        WindowInsets.systemBars.only(
+                                            WindowInsetsSides.Top + WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom,
+                                        ),
+                                    )
+                                    .pointerInput(Unit) {
+                                        detectDragGestures { change, dragAmount ->
+                                            change.consume()
+                                            if (dragAmount.y > 15) {
+                                                state.collapseSoft()
+                                            } else if (dragAmount.y < -15) {
+                                                openQueue()
+                                            }
+                                        }
+                                    }
+                                    .nestedScroll(state.preUpPostDownNestedScrollConnection),
                         )
                     }
                 } else {
@@ -1814,6 +1960,79 @@ fun BottomSheetPlayer(
                                             WindowInsetsSides.Top + WindowInsetsSides.Horizontal,
                                         ),
                                     ).nestedScroll(state.preUpPostDownNestedScrollConnection),
+                        )
+                    }
+                } else if (playerDesignStyle == PlayerDesignStyle.V10) {
+                    enrichedMetadata?.let { metadata ->
+                        V10PlayerContent(
+                            mediaMetadata = metadata,
+                            playbackState = playbackState,
+                            isPlaying = isPlaying,
+                            isLoading = isLoading,
+                            canSkipPrevious = canSkipPrevious,
+                            canSkipNext = canSkipNext,
+                            sliderPosition = sliderPosition,
+                            position = position,
+                            duration = duration,
+                            playerConnection = playerConnection,
+                            navController = navController,
+                            state = state,
+                            textBackgroundColor = dynamicV10AccentColor,
+                            textButtonColor = dynamicV10FieldColor,
+                            iconButtonColor = iconButtonColor,
+                            onCollapseClick = { state.collapseSoft() },
+                            onQueueClick = openQueue,
+                            onLyricsClick = { isLyricsScreenVisible = true },
+                            onSliderValueChange = onSliderValueChange,
+                            onSliderValueChangeFinished = onSliderValueChangeFinished,
+                            onSleepTimerClick = {
+                                if (sleepTimerEnabled) {
+                                    playerConnection.service.sleepTimer.clear()
+                                } else {
+                                    showSleepTimerDialog = true
+                                }
+                            },
+                            sleepTimerEnabled = sleepTimerEnabled,
+                            sleepTimerTimeLeft = sleepTimerTimeLeft,
+                            onMenuClick = {
+                                menuState.show {
+                                    PlayerMenu(
+                                        mediaMetadata = metadata,
+                                        navController = navController,
+                                        playerBottomSheetState = state,
+                                        onShowDetailsDialog = {
+                                            bottomSheetPageState.show {
+                                                ShowMediaInfo(metadata.id)
+                                            }
+                                        },
+                                        onDismiss = menuState::dismiss,
+                                    )
+                                }
+                            },
+                            onAddToPlaylistClick = {
+                                showChoosePlaylistDialog = true
+                            },
+                            landscape = false,
+                            modifier =
+                                Modifier
+                                    .fillMaxSize()
+                                    .padding(bottom = queueSheetState.collapsedBound)
+                                    .windowInsetsPadding(
+                                        WindowInsets.systemBars.only(
+                                            WindowInsetsSides.Top + WindowInsetsSides.Horizontal,
+                                        ),
+                                    )
+                                    .pointerInput(Unit) {
+                                        detectDragGestures { change, dragAmount ->
+                                            change.consume()
+                                            if (dragAmount.y > 15) {
+                                                state.collapseSoft()
+                                            } else if (dragAmount.y < -15) {
+                                                openQueue()
+                                            }
+                                        }
+                                    }
+                                    .nestedScroll(state.preUpPostDownNestedScrollConnection),
                         )
                     }
                 } else {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerComponents.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerComponents.kt
@@ -46,11 +46,20 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.InlineTextContent
 import androidx.compose.foundation.text.appendInlineContent
 import androidx.compose.material3.CircularWavyProgressIndicator
+import androidx.compose.material3.LinearWavyProgressIndicator
+import androidx.compose.material3.LoadingIndicator
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.platform.LocalDensity
+
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FilledIconButton
@@ -75,12 +84,17 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.animation.core.animateFloatAsState
 import moe.rukamori.archivetune.ui.component.LocalMenuState
 import kotlinx.coroutines.delay
+import androidx.compose.runtime.rememberCoroutineScope
+import kotlinx.coroutines.launch
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawWithCache
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -88,6 +102,22 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.ColorMatrix
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.layout.ContentScale
+import androidx.graphics.shapes.Morph
+import androidx.graphics.shapes.RoundedPolygon
+import androidx.graphics.shapes.toPath
+import androidx.compose.ui.graphics.asComposePath
+import androidx.compose.ui.graphics.Matrix
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.animation.Crossfade
+import androidx.compose.animation.core.Animatable
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.material3.MaterialShapes
+import kotlin.math.abs
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.painterResource
@@ -711,7 +741,7 @@ fun PlayerTopActions(
             }
         }
 
-        PlayerDesignStyle.V7, PlayerDesignStyle.V8, PlayerDesignStyle.V9 -> {
+        PlayerDesignStyle.V7, PlayerDesignStyle.V8, PlayerDesignStyle.V9, PlayerDesignStyle.V10 -> {
             Unit
         }
     }
@@ -1770,7 +1800,7 @@ fun PlayerPlaybackControls(
             }
         }
 
-        PlayerDesignStyle.V7, PlayerDesignStyle.V8, PlayerDesignStyle.V9 -> {
+        PlayerDesignStyle.V7, PlayerDesignStyle.V8, PlayerDesignStyle.V9, PlayerDesignStyle.V10 -> {
             Unit
         }
     }
@@ -3359,7 +3389,7 @@ private fun V9PortraitContent(
             Spacer(Modifier.height(if (compactHeight) 16.dp else 24.dp))
 
             // TRANSPORT CONTROLS (Material Extended animated weight style, placed at the bottom)
-            val motionScheme = remember { MotionScheme.expressive() }
+            val motionScheme = remember { MotionScheme.standard() }
             val controlSpatialSpec = remember { motionScheme.fastSpatialSpec<Float>() }
             V9AnimatedPlaybackControls(
                 modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
@@ -3484,7 +3514,7 @@ private fun V9LandscapeContent(
 
                 Spacer(Modifier.height(12.dp))
 
-                val motionScheme = remember { MotionScheme.expressive() }
+                val motionScheme = remember { MotionScheme.standard() }
                 val controlSpatialSpec = remember { motionScheme.fastSpatialSpec<Float>() }
                 V9AnimatedPlaybackControls(
                     modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
@@ -4340,3 +4370,760 @@ fun PlayerBackground(
         }
     }
 }
+
+@Composable
+fun AutoResizeText(
+    text: String,
+    style: TextStyle,
+    color: Color,
+    modifier: Modifier = Modifier,
+) {
+    var fontSizeValue by remember(text) { mutableStateOf(style.fontSize) }
+    var readyToDraw by remember(text) { mutableStateOf(false) }
+
+    Text(
+        text = text,
+        style = style.copy(fontSize = fontSizeValue),
+        color = color,
+        maxLines = 1,
+        overflow = TextOverflow.Clip,
+        onTextLayout = { textLayoutResult ->
+            if (textLayoutResult.hasVisualOverflow && fontSizeValue.value > 10f) {
+                fontSizeValue = (fontSizeValue.value * 0.9f).sp
+            } else {
+                readyToDraw = true
+            }
+        },
+        modifier = modifier.drawWithContent {
+            if (readyToDraw) {
+                drawContent()
+            }
+        }
+    )
+}
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun V10PlayerContent(
+    mediaMetadata: MediaMetadata,
+    playbackState: Int,
+    isPlaying: Boolean,
+    isLoading: Boolean,
+    canSkipPrevious: Boolean,
+    canSkipNext: Boolean,
+    sliderPosition: Long?,
+    position: Long,
+    duration: Long,
+    playerConnection: PlayerConnection,
+    navController: NavController,
+    state: BottomSheetState,
+    textBackgroundColor: Color,
+    textButtonColor: Color,
+    iconButtonColor: Color,
+    onCollapseClick: () -> Unit,
+    onQueueClick: () -> Unit,
+    onLyricsClick: () -> Unit,
+    onSliderValueChange: (Long) -> Unit,
+    onSliderValueChangeFinished: () -> Unit,
+    onSleepTimerClick: () -> Unit,
+    sleepTimerEnabled: Boolean,
+    sleepTimerTimeLeft: Long,
+    onMenuClick: () -> Unit,
+    onAddToPlaylistClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    landscape: Boolean = false,
+) {
+    val baseArtworkUrl = mediaMetadata.thumbnailUrl?.highRes()
+    val thumbnailSwapState =
+        rememberThumbnailSwapState(
+            videoId = mediaMetadata.id,
+            ytmUrl = baseArtworkUrl,
+            lowDataMode = rememberLowDataModeActive(),
+            isMusicVideo = mediaMetadata.isMusicVideo,
+        )
+    val artworkUrl = thumbnailSwapState.displayUrl
+    val titleActions = rememberPlayerTitleActions(mediaMetadata, navController, state)
+    val onTitleClick = titleActions.onTitleClick
+    val onArtistClick = titleActions.onArtistClick
+    val onPlayPauseClick = {
+        if (playbackState == STATE_ENDED) {
+            playerConnection.player.seekTo(0, 0)
+            playerConnection.player.playWhenReady = true
+        } else {
+            playerConnection.player.togglePlayPause()
+        }
+    }
+
+    val shuffleModeEnabled by playerConnection.shuffleModeEnabled.collectAsState()
+    val repeatMode by playerConnection.repeatMode.collectAsState()
+    val currentSong by playerConnection.currentSong.collectAsState(initial = null)
+    val liked = currentSong?.song?.liked == true
+    val onToggleLike = playerConnection::toggleLike
+
+    // The two-tone contract: field + accent, nothing else.
+    // textBackgroundColor = accent (text/icon color), textButtonColor = field (fill color)
+    val accent = textBackgroundColor
+    val field = textButtonColor
+
+    // ========== MAIN LAYOUT (EditorialNowPlayingView) ==========
+    Column(modifier = modifier.fillMaxSize()) {
+
+        // ========== TOP BAR (No statusBarsPadding to give breathing space/hide status bar) ==========
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp, vertical = 20.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            EditorialCircleButton(
+                onClick = onCollapseClick,
+                accent = accent,
+                field = field,
+                size = 44.dp
+            ) {
+                Icon(painter = painterResource(R.drawable.expand_more), contentDescription = "Collapse", modifier = Modifier.size(26.dp))
+            }
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                if (sleepTimerEnabled) {
+                    val countdownText = makeTimeString(sleepTimerTimeLeft.coerceAtLeast(0L))
+                    Surface(
+                        onClick = onSleepTimerClick,
+                        shape = CircleShape,
+                        color = accent,
+                        contentColor = field,
+                        modifier = Modifier.height(44.dp)
+                    ) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.Center,
+                            modifier = Modifier.padding(horizontal = 16.dp)
+                        ) {
+                            Text(
+                                text = countdownText,
+                                style = MaterialTheme.typography.labelLarge.copy(fontWeight = FontWeight.Bold)
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Icon(
+                                painter = painterResource(R.drawable.bedtime),
+                                contentDescription = "Sleep timer",
+                                modifier = Modifier.size(18.dp)
+                            )
+                        }
+                    }
+                } else {
+                    EditorialCircleButton(
+                        onClick = onSleepTimerClick,
+                        accent = field,
+                        field = accent,
+                        size = 44.dp
+                    ) {
+                        Icon(painter = painterResource(R.drawable.bedtime), contentDescription = "Sleep timer", modifier = Modifier.size(22.dp))
+                    }
+                }
+
+                EditorialCircleButton(
+                    onClick = onLyricsClick,
+                    accent = accent,
+                    field = field,
+                    size = 44.dp
+                ) {
+                    Icon(painter = painterResource(R.drawable.lyrics), contentDescription = "Lyrics", modifier = Modifier.size(22.dp))
+                }
+                EditorialCircleButton(
+                    onClick = onMenuClick,
+                    accent = accent,
+                    field = field,
+                    size = 44.dp
+                ) {
+                    Icon(painter = painterResource(R.drawable.more_vert), contentDescription = "More", modifier = Modifier.size(22.dp))
+                }
+            }
+        }
+
+        // ========== DIE-CUT ART ==========
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1.0f),
+            contentAlignment = Alignment.Center
+        ) {
+            EditorialDieCutArt(
+                artworkUrl = artworkUrl,
+                mediaMetadataId = mediaMetadata.id,
+                isPlaying = isPlaying,
+                onTap = onPlayPauseClick,
+                accent = accent,
+                field = field,
+                canSkipPrevious = canSkipPrevious,
+                canSkipNext = canSkipNext,
+                onSkipPrevious = { playerConnection.player.seekToPrevious() },
+                onSkipNext = { playerConnection.player.seekToNext() }
+            )
+        }
+
+        // ========== HEADLINE ==========
+        val title = mediaMetadata.title
+        val headlineBase = when {
+            title.length <= 12 -> MaterialTheme.typography.displayLarge
+            title.length <= 24 -> MaterialTheme.typography.displayMedium
+            else -> MaterialTheme.typography.displaySmall
+        }
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 8.dp)
+        ) {
+            Text(
+                text = title,
+                style = headlineBase.copy(
+                    fontFamily = FontFamily.Serif,
+                    fontStyle = FontStyle.Italic,
+                    fontWeight = FontWeight.Bold
+                ),
+                color = accent,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp)
+            )
+
+            val artistName = remember(mediaMetadata.artists) {
+                mediaMetadata.artists.joinToString(", ") { it.name }
+            }
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp, vertical = 4.dp)
+                    .clip(RoundedCornerShape(8.dp))
+                    .clickable {
+                        mediaMetadata.artists.firstOrNull()?.id?.let(onArtistClick)
+                    }
+                    .padding(horizontal = 4.dp, vertical = 4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Start
+            ) {
+                if (mediaMetadata.explicit) {
+                    Icon(
+                        painter = painterResource(R.drawable.explicit),
+                        contentDescription = "Explicit",
+                        tint = accent.copy(alpha = 0.8f),
+                        modifier = Modifier
+                            .padding(end = 6.dp)
+                            .size(16.dp)
+                    )
+                }
+                Text(
+                    text = artistName.uppercase(),
+                    style = MaterialTheme.typography.labelLarge.copy(letterSpacing = 2.sp),
+                    color = accent.copy(alpha = 0.8f),
+                    maxLines = 1,
+                    modifier = Modifier.basicMarquee(
+                        iterations = Int.MAX_VALUE,
+                        initialDelayMillis = 2000
+                    )
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(4.dp))
+
+        // ========== CONTROL CLUSTER (asymmetric bento) ==========
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp)
+        ) {
+            // Row 1: word pill + next circle
+            val haptic = androidx.compose.ui.platform.LocalHapticFeedback.current
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(80.dp),
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Surface(
+                    onClick = onPlayPauseClick,
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxHeight(),
+                    shape = RoundedCornerShape(50),
+                    color = accent,
+                    contentColor = field
+                ) {
+                    Box(contentAlignment = Alignment.Center) {
+                        if (isLoading && !isPlaying) {
+                            LoadingIndicator(
+                                modifier = Modifier.size(36.dp),
+                                color = field,
+                                polygons = listOf(
+                                    MaterialShapes.SoftBurst,
+                                    MaterialShapes.Cookie9Sided,
+                                    MaterialShapes.Pill,
+                                    MaterialShapes.Sunny
+                                )
+                            )
+                        } else {
+                            AnimatedContent(
+                                targetState = isPlaying,
+                                label = "EditorialPlayWord"
+                            ) { playing ->
+                                Text(
+                                    text = if (playing) "PAUSE" else "PLAY",
+                                    style = MaterialTheme.typography.headlineSmall.copy(
+                                        fontWeight = FontWeight.Medium,
+                                        letterSpacing = 3.sp
+                                    )
+                                )
+                            }
+                        }
+                    }
+                }
+                EditorialCircleButton(
+                    onClick = {
+                        haptic.performHapticFeedback(androidx.compose.ui.hapticfeedback.HapticFeedbackType.LongPress)
+                        playerConnection.seekToNext()
+                    },
+                    accent = accent,
+                    field = field,
+                    size = 80.dp
+                ) {
+                    Icon(painter = painterResource(R.drawable.skip_next), contentDescription = "Next", modifier = Modifier.size(34.dp))
+                }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // Row 2: previous circle + progress line with times
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                EditorialCircleButton(
+                    onClick = {
+                        haptic.performHapticFeedback(androidx.compose.ui.hapticfeedback.HapticFeedbackType.LongPress)
+                        playerConnection.seekToPrevious()
+                    },
+                    accent = accent,
+                    field = field,
+                    size = 80.dp
+                ) {
+                    Icon(painter = painterResource(R.drawable.skip_previous), contentDescription = "Previous", modifier = Modifier.size(34.dp))
+                }
+
+                Column(modifier = Modifier.weight(1f)) {
+                    var scrubPosition by remember { mutableStateOf<Float?>(null) }
+                    val displayedProgress = scrubPosition?.toLong() ?: (sliderPosition ?: position)
+                    val progressFraction =
+                        if (duration > 0) displayedProgress.toFloat() / duration.toFloat() else 0f
+                    val animatedProgress by animateFloatAsState(
+                        targetValue = progressFraction,
+                        animationSpec = spring(
+                            dampingRatio = Spring.DampingRatioNoBouncy,
+                            stiffness = Spring.StiffnessLow
+                        ),
+                        label = "EditorialProgress"
+                    )
+                    val lineStroke = Stroke(
+                        width = with(LocalDensity.current) { 4.dp.toPx() },
+                        cap = StrokeCap.Round
+                    )
+
+                    Box(contentAlignment = Alignment.Center) {
+                        LinearWavyProgressIndicator(
+                            progress = { animatedProgress },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(14.dp),
+                            color = accent,
+                            trackColor = accent.copy(alpha = 0.35f),
+                            stroke = lineStroke,
+                            trackStroke = lineStroke,
+                            amplitude = { if (isPlaying) 1f else 0f }
+                        )
+                        Slider(
+                            value = scrubPosition ?: (sliderPosition ?: position).toFloat(),
+                            onValueChange = { scrubPosition = it },
+                            onValueChangeFinished = {
+                                scrubPosition?.let { onSliderValueChange(it.toLong()) }
+                                onSliderValueChangeFinished()
+                                scrubPosition = null
+                            },
+                            valueRange = 0f..(duration.toFloat().coerceAtLeast(1f)),
+                            colors = SliderDefaults.colors(
+                                thumbColor = Color.Transparent,
+                                activeTrackColor = Color.Transparent,
+                                inactiveTrackColor = Color.Transparent
+                            ),
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    }
+
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween
+                    ) {
+                        Text(
+                            text = formatEditorialTime(displayedProgress.coerceAtLeast(0L)),
+                            style = MaterialTheme.typography.labelMedium,
+                            color = accent.copy(alpha = 0.8f)
+                        )
+                        Text(
+                            text = formatEditorialTime(duration.coerceAtLeast(0L)),
+                            style = MaterialTheme.typography.labelMedium,
+                            color = accent.copy(alpha = 0.8f)
+                        )
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(18.dp))
+
+            // ========== CHIPS ROW ==========
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 8.dp),
+                horizontalArrangement = Arrangement.SpaceAround // Spread the buttons wider apart
+            ) {
+                EditorialChip(
+                    checked = liked,
+                    onClick = { onToggleLike() },
+                    accent = accent,
+                    field = field
+                ) {
+                    Icon(
+                        painter = painterResource(if (liked) R.drawable.favorite else R.drawable.favorite_border),
+                        contentDescription = "Like",
+                        modifier = Modifier.size(20.dp)
+                    )
+                }
+                EditorialChip(
+                    checked = shuffleModeEnabled,
+                    onClick = {
+                        try {
+                            playerConnection.player.shuffleModeEnabled = !shuffleModeEnabled
+                        } catch (_: Exception) {}
+                    },
+                    accent = accent,
+                    field = field
+                ) {
+                    Icon(painter = painterResource(R.drawable.shuffle), contentDescription = "Shuffle", modifier = Modifier.size(20.dp))
+                }
+                EditorialChip(
+                    checked = repeatMode != Player.REPEAT_MODE_OFF,
+                    onClick = {
+                        try {
+                            playerConnection.player.toggleRepeatMode()
+                        } catch (_: Exception) {}
+                    },
+                    accent = accent,
+                    field = field
+                ) {
+                    Icon(
+                        painter = painterResource(if (repeatMode == Player.REPEAT_MODE_ONE) R.drawable.repeat_one else R.drawable.repeat),
+                        contentDescription = "Repeat",
+                        modifier = Modifier.size(20.dp)
+                    )
+                }
+                EditorialChip(
+                    checked = false,
+                    onClick = onAddToPlaylistClick,
+                    accent = accent,
+                    field = field
+                ) {
+                    Icon(painter = painterResource(R.drawable.library_add), contentDescription = "Add to playlist", modifier = Modifier.size(20.dp))
+                }
+            }
+        }
+
+        Spacer(
+            modifier = Modifier
+                .navigationBarsPadding()
+                .height(6.dp)
+        )
+    }
+}
+
+// ========== HELPERS ==========
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun EditorialDieCutArt(
+    artworkUrl: String?,
+    mediaMetadataId: String,
+    isPlaying: Boolean,
+    onTap: () -> Unit,
+    accent: Color,
+    field: Color,
+    canSkipPrevious: Boolean,
+    canSkipNext: Boolean,
+    onSkipPrevious: () -> Unit,
+    onSkipNext: () -> Unit
+) {
+    val dieCuts = remember {
+        listOf(
+            MaterialShapes.Flower,
+            MaterialShapes.Clover4Leaf,
+            MaterialShapes.Puffy,
+            MaterialShapes.Cookie12Sided,
+            MaterialShapes.SoftBurst
+        )
+    }
+    val targetPolygon = remember(mediaMetadataId) {
+        dieCuts[abs(mediaMetadataId.hashCode()) % dieCuts.size]
+    }
+
+    var morphFrom by remember { mutableStateOf(targetPolygon) }
+    var morphTo by remember { mutableStateOf(targetPolygon) }
+    val morphProgress = remember { Animatable(1f) }
+    LaunchedEffect(targetPolygon) {
+        if (targetPolygon !== morphTo) {
+            morphFrom = morphTo
+            morphTo = targetPolygon
+            morphProgress.snapTo(0f)
+            morphProgress.animateTo(
+                targetValue = 1f,
+                animationSpec = spring(
+                    dampingRatio = Spring.DampingRatioLowBouncy,
+                    stiffness = Spring.StiffnessLow
+                )
+            )
+        }
+    }
+    val morph = remember(morphFrom, morphTo) { Morph(morphFrom, morphTo) }
+    val dieCutShape = remember(morph, morphProgress.value) {
+        EditorialMorphShape(morph, morphProgress.value)
+    }
+
+    val artScale by animateFloatAsState(
+        targetValue = if (isPlaying) 1f else 0.94f,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioMediumBouncy,
+            stiffness = Spring.StiffnessLow
+        ),
+        label = "EditorialArtScale"
+    )
+
+    BoxWithConstraints(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        if (maxWidth < 50.dp || maxHeight < 50.dp) return@BoxWithConstraints
+        val artSize = minOf(maxWidth, maxHeight) * 0.95f
+
+        val view = androidx.compose.ui.platform.LocalView.current
+        val (enableHapticFeedback) = rememberPreference(moe.rukamori.archivetune.constants.EnableHapticFeedbackKey, true)
+        val coroutineScope = rememberCoroutineScope()
+
+        // Visual feedback variables
+        var skipIndicator by remember { mutableStateOf<String?>(null) } // "prev", "next", or "play_pause"
+        val skipIndicatorAlpha = remember { Animatable(0f) }
+
+        Box(
+            modifier = Modifier
+                .size(artSize)
+                .graphicsLayer {
+                    scaleX = artScale
+                    scaleY = artScale
+                }
+                .clip(dieCutShape)
+                .background(accent)
+                .pointerInput(canSkipPrevious, canSkipNext) {
+                    detectTapGestures(
+                        onTap = { offset ->
+                            val xFraction = offset.x / size.width.toFloat()
+                            if (xFraction < 0.3f && canSkipPrevious) {
+                                if (enableHapticFeedback) {
+                                    view.performHapticFeedback(
+                                        android.view.HapticFeedbackConstants.KEYBOARD_TAP,
+                                        android.view.HapticFeedbackConstants.FLAG_IGNORE_GLOBAL_SETTING
+                                    )
+                                }
+                                onSkipPrevious()
+                                skipIndicator = "prev"
+                                coroutineScope.launch {
+                                    skipIndicatorAlpha.snapTo(0.8f)
+                                    skipIndicatorAlpha.animateTo(0f, tween(400))
+                                    skipIndicator = null
+                                }
+                            } else if (xFraction > 0.7f && canSkipNext) {
+                                if (enableHapticFeedback) {
+                                    view.performHapticFeedback(
+                                        android.view.HapticFeedbackConstants.KEYBOARD_TAP,
+                                        android.view.HapticFeedbackConstants.FLAG_IGNORE_GLOBAL_SETTING
+                                    )
+                                }
+                                onSkipNext()
+                                skipIndicator = "next"
+                                coroutineScope.launch {
+                                    skipIndicatorAlpha.snapTo(0.8f)
+                                    skipIndicatorAlpha.animateTo(0f, tween(400))
+                                    skipIndicator = null
+                                }
+                            } else {
+                                if (enableHapticFeedback) {
+                                    view.performHapticFeedback(
+                                        android.view.HapticFeedbackConstants.KEYBOARD_TAP,
+                                        android.view.HapticFeedbackConstants.FLAG_IGNORE_GLOBAL_SETTING
+                                    )
+                                }
+                                onTap()
+                                skipIndicator = "play_pause"
+                                coroutineScope.launch {
+                                    skipIndicatorAlpha.snapTo(0.6f)
+                                    skipIndicatorAlpha.animateTo(0f, tween(300))
+                                    skipIndicator = null
+                                }
+                            }
+                        }
+                    )
+                },
+            contentAlignment = Alignment.Center
+        ) {
+            if (artworkUrl != null) {
+                AsyncImage(
+                    model = artworkUrl,
+                    contentDescription = "Album Art",
+                    modifier = Modifier.fillMaxSize(),
+                    contentScale = ContentScale.Crop
+                )
+            } else {
+                Icon(
+                    painter = painterResource(R.drawable.music_note),
+                    contentDescription = null,
+                    tint = field,
+                    modifier = Modifier.size(artSize * 0.3f)
+                )
+            }
+
+            // Visual overlay indicator
+            if (skipIndicator != null) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(Color.Black.copy(alpha = 0.2f * skipIndicatorAlpha.value)),
+                    contentAlignment = Alignment.Center
+                ) {
+                    val iconRes = when (skipIndicator) {
+                        "prev" -> R.drawable.skip_previous
+                        "next" -> R.drawable.skip_next
+                        else -> if (isPlaying) R.drawable.pause else R.drawable.play
+                    }
+                    Box(
+                        modifier = Modifier
+                            .size(72.dp)
+                            .clip(CircleShape)
+                            .background(field.copy(alpha = 0.8f * skipIndicatorAlpha.value)),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Icon(
+                            painter = painterResource(iconRes),
+                            contentDescription = null,
+                            tint = accent,
+                            modifier = Modifier.size(36.dp)
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+internal fun EditorialCircleButton(
+    onClick: () -> Unit,
+    accent: Color,
+    field: Color,
+    size: Dp,
+    content: @Composable () -> Unit
+) {
+    FilledIconButton(
+        onClick = onClick,
+        shape = CircleShape,
+        colors = IconButtonDefaults.filledIconButtonColors(
+            containerColor = accent,
+            contentColor = field
+        ),
+        modifier = Modifier.size(size)
+    ) {
+        content()
+    }
+}
+
+@Composable
+internal fun EditorialChip(
+    checked: Boolean,
+    onClick: () -> Unit,
+    accent: Color,
+    field: Color,
+    content: @Composable () -> Unit
+) {
+    Surface(
+        onClick = onClick,
+        shape = CircleShape,
+        color = if (checked) accent else Color.Transparent,
+        contentColor = if (checked) field else accent,
+        modifier = Modifier.size(48.dp)
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            content()
+        }
+    }
+}
+
+internal class EditorialMorphShape(
+    private val morph: Morph,
+    private val progress: Float
+) : Shape {
+    override fun createOutline(
+        size: Size,
+        layoutDirection: LayoutDirection,
+        density: Density
+    ): Outline {
+        val path = morph.toPath(progress).asComposePath()
+        val matrix = Matrix()
+        val bounds = morph.calculateBounds()
+        val boundsWidth = bounds[2] - bounds[0]
+        val boundsHeight = bounds[3] - bounds[1]
+
+        matrix.scale(size.width / boundsWidth, size.height / boundsHeight)
+        matrix.translate(-bounds[0], -bounds[1])
+        path.transform(matrix)
+        return Outline.Generic(path)
+    }
+}
+
+internal class EditorialPolygonShape(
+    private val polygon: RoundedPolygon
+) : Shape {
+    override fun createOutline(
+        size: Size,
+        layoutDirection: LayoutDirection,
+        density: Density
+    ): Outline {
+        val path = polygon.toPath().asComposePath()
+        val matrix = Matrix()
+        val bounds = polygon.calculateBounds()
+        val boundsWidth = bounds[2] - bounds[0]
+        val boundsHeight = bounds[3] - bounds[1]
+
+        matrix.scale(size.width / boundsWidth, size.height / boundsHeight)
+        matrix.translate(-bounds[0], -bounds[1])
+        path.transform(matrix)
+        return Outline.Generic(path)
+    }
+}
+
+internal fun formatEditorialTime(durationMs: Long): String {
+    val totalSeconds = durationMs / 1000
+    val minutes = totalSeconds / 60
+    val seconds = totalSeconds % 60
+    return String.format("%d:%02d", minutes, seconds)
+}
+

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerComponents.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerComponents.kt
@@ -115,6 +115,7 @@ import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.Animatable
 import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.material3.MaterialShapes
 import kotlin.math.abs
@@ -4788,7 +4789,15 @@ fun V10PlayerContent(
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(bottom = 8.dp),
+                    .padding(bottom = 8.dp)
+                    .pointerInput(Unit) {
+                        detectVerticalDragGestures { change, dragAmount ->
+                            if (dragAmount < -15) {
+                                change.consume()
+                                onQueueClick()
+                            }
+                        }
+                    },
                 horizontalArrangement = Arrangement.SpaceAround // Spread the buttons wider apart
             ) {
                 EditorialChip(
@@ -4933,57 +4942,7 @@ private fun EditorialDieCutArt(
                     scaleY = artScale
                 }
                 .clip(dieCutShape)
-                .background(accent)
-                .pointerInput(canSkipPrevious, canSkipNext) {
-                    detectTapGestures(
-                        onTap = { offset ->
-                            val xFraction = offset.x / size.width.toFloat()
-                            if (xFraction < 0.3f && canSkipPrevious) {
-                                if (enableHapticFeedback) {
-                                    view.performHapticFeedback(
-                                        android.view.HapticFeedbackConstants.KEYBOARD_TAP,
-                                        android.view.HapticFeedbackConstants.FLAG_IGNORE_GLOBAL_SETTING
-                                    )
-                                }
-                                onSkipPrevious()
-                                skipIndicator = "prev"
-                                coroutineScope.launch {
-                                    skipIndicatorAlpha.snapTo(0.8f)
-                                    skipIndicatorAlpha.animateTo(0f, tween(400))
-                                    skipIndicator = null
-                                }
-                            } else if (xFraction > 0.7f && canSkipNext) {
-                                if (enableHapticFeedback) {
-                                    view.performHapticFeedback(
-                                        android.view.HapticFeedbackConstants.KEYBOARD_TAP,
-                                        android.view.HapticFeedbackConstants.FLAG_IGNORE_GLOBAL_SETTING
-                                    )
-                                }
-                                onSkipNext()
-                                skipIndicator = "next"
-                                coroutineScope.launch {
-                                    skipIndicatorAlpha.snapTo(0.8f)
-                                    skipIndicatorAlpha.animateTo(0f, tween(400))
-                                    skipIndicator = null
-                                }
-                            } else {
-                                if (enableHapticFeedback) {
-                                    view.performHapticFeedback(
-                                        android.view.HapticFeedbackConstants.KEYBOARD_TAP,
-                                        android.view.HapticFeedbackConstants.FLAG_IGNORE_GLOBAL_SETTING
-                                    )
-                                }
-                                onTap()
-                                skipIndicator = "play_pause"
-                                coroutineScope.launch {
-                                    skipIndicatorAlpha.snapTo(0.6f)
-                                    skipIndicatorAlpha.animateTo(0f, tween(300))
-                                    skipIndicator = null
-                                }
-                            }
-                        }
-                    )
-                },
+                .background(accent),
             contentAlignment = Alignment.Center
         ) {
             if (artworkUrl != null) {
@@ -5000,36 +4959,6 @@ private fun EditorialDieCutArt(
                     tint = field,
                     modifier = Modifier.size(artSize * 0.3f)
                 )
-            }
-
-            // Visual overlay indicator
-            if (skipIndicator != null) {
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .background(Color.Black.copy(alpha = 0.2f * skipIndicatorAlpha.value)),
-                    contentAlignment = Alignment.Center
-                ) {
-                    val iconRes = when (skipIndicator) {
-                        "prev" -> R.drawable.skip_previous
-                        "next" -> R.drawable.skip_next
-                        else -> if (isPlaying) R.drawable.pause else R.drawable.play
-                    }
-                    Box(
-                        modifier = Modifier
-                            .size(72.dp)
-                            .clip(CircleShape)
-                            .background(field.copy(alpha = 0.8f * skipIndicatorAlpha.value)),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Icon(
-                            painter = painterResource(iconRes),
-                            contentDescription = null,
-                            tint = accent,
-                            modifier = Modifier.size(36.dp)
-                        )
-                    }
-                }
             }
         }
     }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerComponents.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerComponents.kt
@@ -3240,7 +3240,7 @@ private fun V9PortraitContent(
                     canvasPrimaryUrl = canvasPrimaryUrl,
                     canvasFallbackUrl = canvasFallbackUrl,
                     isPlaying = isPlaying,
-                    placeholderColor = textButtonColor.copy(alpha = 0.12f),
+                    placeholderColor = textBackgroundColor.copy(alpha = 0.08f),
                     modifier = Modifier.aspectRatio(1f)
                 )
             }
@@ -3321,9 +3321,9 @@ private fun V9PortraitContent(
                         onSliderValueChangeFinished()
                     },
                     enabled = duration > 0L,
-                    activeTrackColor = textButtonColor,
-                    inactiveTrackColor = textButtonColor.copy(alpha = 0.24f),
-                    thumbColor = textButtonColor,
+                    activeTrackColor = textBackgroundColor,
+                    inactiveTrackColor = textBackgroundColor.copy(alpha = 0.24f),
+                    thumbColor = textBackgroundColor,
                     isPlaying = isPlaying,
                     isVisible = true,
                     modifier = Modifier
@@ -3370,9 +3370,9 @@ private fun V9PortraitContent(
                 height = 80.dp,
                 pressAnimationSpec = controlSpatialSpec,
                 releaseDelay = 220L,
-                colorOtherButtons = textButtonColor.copy(alpha = 0.16f),
-                colorPlayPause = textButtonColor,
-                tintPlayPauseIcon = iconButtonColor,
+                colorOtherButtons = textBackgroundColor.copy(alpha = 0.08f),
+                colorPlayPause = textBackgroundColor,
+                tintPlayPauseIcon = if ((textBackgroundColor.red + textBackgroundColor.green + textBackgroundColor.blue) > 1.5f) Color.Black else Color.White,
                 tintOtherIcons = textBackgroundColor,
             )
 
@@ -3438,7 +3438,7 @@ private fun V9LandscapeContent(
                 canvasFallbackUrl = canvasFallbackUrl,
                 isPlaying = isPlaying,
                 size = artworkSize,
-                placeholderColor = textButtonColor.copy(alpha = 0.12f),
+                placeholderColor = textBackgroundColor.copy(alpha = 0.08f),
             )
 
             Column(
@@ -3475,8 +3475,8 @@ private fun V9LandscapeContent(
                     position = position,
                     duration = duration,
                     isPlaying = isPlaying,
-                    activeColor = textButtonColor,
-                    inactiveColor = textButtonColor.copy(alpha = 0.24f),
+                    activeColor = textBackgroundColor,
+                    inactiveColor = textBackgroundColor.copy(alpha = 0.24f),
                     textColor = textBackgroundColor,
                     onSliderValueChange = onSliderValueChange,
                     onSliderValueChangeFinished = onSliderValueChangeFinished,
@@ -3495,9 +3495,9 @@ private fun V9LandscapeContent(
                     height = 64.dp,
                     pressAnimationSpec = controlSpatialSpec,
                     releaseDelay = 220L,
-                    colorOtherButtons = textButtonColor.copy(alpha = 0.14f),
-                    colorPlayPause = textButtonColor,
-                    tintPlayPauseIcon = iconButtonColor,
+                    colorOtherButtons = textBackgroundColor.copy(alpha = 0.08f),
+                    colorPlayPause = textBackgroundColor,
+                    tintPlayPauseIcon = if ((textBackgroundColor.red + textBackgroundColor.green + textBackgroundColor.blue) > 1.5f) Color.Black else Color.White,
                     tintOtherIcons = textBackgroundColor,
                 )
 
@@ -3509,10 +3509,10 @@ private fun V9LandscapeContent(
                     onShuffleClick = onShuffleClick,
                     onRepeatClick = onRepeatClick,
                     onMenuClick = onMenuClick,
-                    activeColor = textButtonColor,
-                    inactiveColor = textButtonColor.copy(alpha = 0.16f),
+                    activeColor = textBackgroundColor,
+                    inactiveColor = textBackgroundColor.copy(alpha = 0.24f),
                     textColor = textBackgroundColor,
-                    containerColor = textButtonColor.copy(alpha = 0.08f),
+                    containerColor = textBackgroundColor.copy(alpha = 0.08f),
                     modifier = Modifier
                         .fillMaxWidth()
                         .height(54.dp),

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Queue.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Queue.kt
@@ -593,7 +593,7 @@ fun Queue(
                     )
                 }
 
-                PlayerDesignStyle.V9 -> {
+                PlayerDesignStyle.V9, PlayerDesignStyle.V10 -> {
                     val shuffleModeEnabled by playerConnection.shuffleModeEnabled.collectAsState()
                     QueueCollapsedContentV9(
                         showCodecOnPlayer = showCodecOnPlayer,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/V9AnimatedPlaybackControls.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/V9AnimatedPlaybackControls.kt
@@ -84,7 +84,7 @@ fun V9AnimatedPlaybackControls(
     val hapticFeedback = LocalHapticFeedback.current
     val coroutineScope = rememberCoroutineScope()
 
-    val motionScheme = remember { MotionScheme.expressive() }
+    val motionScheme = remember { MotionScheme.standard() }
     val defaultSpatialDpSpec = remember { motionScheme.defaultSpatialSpec<Dp>() }
 
     LaunchedEffect(lastClicked, clickTrigger) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AodCustomizedScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AodCustomizedScreen.kt
@@ -160,7 +160,7 @@ private data class AodPreviewSettings(
 @Composable
 fun AodCustomizedScreen(navController: NavController) {
     val scrollBehavior = appBarScrollBehavior()
-    val (aodModeEnabled, onAodModeEnabledChange) = rememberPreference(AodModeEnabledKey, defaultValue = true)
+    val (aodModeEnabled, onAodModeEnabledChange) = rememberPreference(AodModeEnabledKey, defaultValue = false)
     val (thumbnailShape, onThumbnailShapeChange) =
         rememberEnumPreference(
             AodThumbnailShapeKey,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AppearanceSettings.kt
@@ -368,6 +368,7 @@ fun AppearanceSettings(navController: NavController) {
             PlayerDesignStyle.V7,
             PlayerDesignStyle.V8,
             PlayerDesignStyle.V9,
+            PlayerDesignStyle.V10,
             -> false
 
             else -> true
@@ -730,6 +731,7 @@ fun AppearanceSettings(navController: NavController) {
                                 PlayerDesignStyle.V7 -> stringResource(R.string.player_design_v7)
                                 PlayerDesignStyle.V8 -> stringResource(R.string.player_design_v8)
                                 PlayerDesignStyle.V9 -> stringResource(R.string.player_design_v9)
+                                PlayerDesignStyle.V10 -> stringResource(R.string.player_design_v10)
                             }
                         },
                     )

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/theme/Theme.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/theme/Theme.kt
@@ -116,7 +116,7 @@ fun ArchiveTuneTheme(
         }
     val motionScheme =
         remember(disableAnimations) {
-            if (disableAnimations) DisabledMotionScheme else MotionScheme.standard()
+            if (disableAnimations) DisabledMotionScheme else MotionScheme.expressive()
         }
     val paletteStyle =
         remember(themeColor, seedPalette) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/theme/Theme.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/theme/Theme.kt
@@ -116,7 +116,7 @@ fun ArchiveTuneTheme(
         }
     val motionScheme =
         remember(disableAnimations) {
-            if (disableAnimations) DisabledMotionScheme else MotionScheme.expressive()
+            if (disableAnimations) DisabledMotionScheme else MotionScheme.standard()
         }
     val paletteStyle =
         remember(themeColor, seedPalette) {

--- a/app/src/main/res/values/archivetune_strings.xml
+++ b/app/src/main/res/values/archivetune_strings.xml
@@ -338,6 +338,7 @@
     <string name="player_design_v7">Immersive</string>
     <string name="player_design_v8">Immersive Extended</string>
     <string name="player_design_v9">Material Extended</string>
+    <string name="player_design_v10">Editorial</string>
     <string name="player_background_blur">Blur</string>
     <string name="coloring">Coloring</string>
     <string name="blur_gradient">Blur Gradient</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -450,7 +450,7 @@
     <string name="custom_value">Custom value</string>
     <string name="archivetune_canvas">ArchiveTune Canvas</string>
     <string name="archivetune_canvas_desc">Animate album artwork while playing (Powered by BetterLyrics)</string>
-    <string name="player_background_style_v8_v9_desc">Unavailable with V8 and V9 player styles</string>
+    <string name="player_background_style_v8_v9_desc">Unavailable with V8, V9, and V10 player styles</string>
     <string name="show_button1_description">Toggle visibility of button 1 in Discord Rich Presence</string>
     <string name="show_button2_description">Toggle visibility of button 2 in Discord Rich Presence</string>
     <string name="discord_activity_type">Activity type</string>

--- a/app/src/nightly/kotlin/moe/rukamori/archivetune/LeakCanaryVariant.kt
+++ b/app/src/nightly/kotlin/moe/rukamori/archivetune/LeakCanaryVariant.kt
@@ -26,12 +26,11 @@ internal object LeakCanaryVariant {
   private val watchersInstalled = AtomicBoolean(false)
   private val trackingEnabled = AtomicBoolean(false)
   private val leakCanaryEnabledKey = booleanPreferencesKey(LeakCanaryToggle.PREFERENCE_KEY)
-  private val gatedReachabilityWatcher =
-    ReachabilityWatcher { watchedObject, description ->
-      if (trackingEnabled.get()) {
-        AppWatcher.objectWatcher.expectWeaklyReachable(watchedObject, description)
-      }
+  private val gatedReachabilityWatcher = ReachabilityWatcher { watchedObject, description ->
+    if (trackingEnabled.get()) {
+      AppWatcher.objectWatcher.expectWeaklyReachable(watchedObject, description)
     }
+  }
 
   @JvmStatic
   fun initialize(application: Application) {
@@ -41,9 +40,7 @@ internal object LeakCanaryVariant {
       application.dataStore.data
         .map { preferences -> preferences[leakCanaryEnabledKey] ?: false }
         .distinctUntilChanged()
-        .collect { enabled ->
-          application.mainExecutor.execute { applyTrackingEnabled(enabled) }
-        }
+        .collect { enabled -> application.mainExecutor.execute { applyTrackingEnabled(enabled) } }
     }
   }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -46,6 +46,7 @@ aboutLibraries = "15.0.3"
 leakCanary = "2.14"
 spotless = "8.10.0"
 chaquopy = "17.0.0"
+graphicsShapes = "1.0.1"
 quickjsKt = "1.0.10"
 bouncyCastle = "1.85"
 
@@ -127,6 +128,7 @@ brotli = { module = "org.brotli:dec", version.ref = "brotli" }
 rhino = { module = "org.mozilla:rhino", version.ref = "rhino" }
 
 desugaring = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugaring" }
+androidx-graphics-shapes = { group = "androidx.graphics", name = "graphics-shapes", version.ref = "graphicsShapes" }
 
 junit = { module = "junit:junit", version.ref = "junit" }
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }


### PR DESCRIPTION
This Pull Request introduces the brand-new V10 'Editorial' player style alongside layout refinements, crash fixes, color extraction enhancements, developer tooling improvements, and global motion tuning.

## V10 Editorial Player
- Implements a sleek, modern, bento-box-style player layout with die-cut shaped album artwork (Flower, Clover, Puffy, Cookie, SoftBurst) that morphs between shapes on track changes.
- Artwork scales subtly based on play/pause state with bouncy spring animations.
- V10 shares the V9 collapsed queue content layout (`QueueCollapsedContentV9`).
- Added `PlayerDesignStyle.V10` to the Appearance Settings picker with the "Editorial" label.
- Updated background style description string to include V10 alongside V8/V9 for unavailability notice.
- Added `androidx.graphics:graphics-shapes` dependency for Material shape morphing.

## V10 Player Gesture & Interaction Fixes
- **Smooth Slide-Down Animation**: Removed the global `detectDragGestures` modifier from `V10PlayerContent` (both portrait and landscape) that was instantly collapsing the player on any downward drag. The native `BottomSheet` fling/drag behavior is now restored, providing smooth, fluid slide-down-to-mini-player animations.
- **Queue Gesture Isolation**: Restricted the swipe-up-to-open-queue gesture exclusively to the bottom Chips Row (the 4-icon control area) using `detectVerticalDragGestures`, preventing accidental queue openings when interacting with other parts of the player.
- **Thumbnail Control Removal**: Removed tap-to-skip-previous, tap-to-skip-next, and tap-to-play/pause controls from the V10 Editorial player's die-cut thumbnail artwork. The artwork is now a clean, purely visual element without gesture interference.

## V10 EditorialChip Crash Fix (Android 16)
- **Root Cause**: Material 3's `Surface(onClick = ...)` internally uses `rememberAnimatedShape` to animate the component's shape on press/release. On Android 16 (SDK 36), the spring-based corner interpolation can momentarily produce negative corner radius values (e.g. `-0.23px`), which `CornerBasedShape.createOutline` rejects with `IllegalArgumentException: Corner size in Px can't be negative`.
- **Fix**: Replaced `Surface` in `EditorialChip` with a plain `Box` + `clip(CircleShape)` + `background(animateColorAsState(...))` + `clickable(...)`, bypassing M3's internal `rememberAnimatedShape` entirely. `CircleShape` always produces valid outlines. The color transition is still smoothly animated via `animateColorAsState`, and `LocalContentColor` is provided so child `Icon` composables pick up the correct tint automatically.
- **Impact**: Fixes crash when tapping Shuffle, Loop, Like, or Add to Playlist chips in the V10 Editorial player on Android 16 devices.

## Color Extraction & Tone Mapping Fixes
- Rewrote the color picker toning logic using proper HCT (Hue-Chroma-Tone) mappings to fix low-saturation color issues (e.g., preventing grayish albums from incorrectly resolving to pink tones on V9/V10).

## Sleep Timer Enhancements
- Replaced custom popup with the standard, polished `SleepTimerDialog` to fix layout wrapping issues.
- Added countdown text mirroring for the active sleep timer pill.

## AOD (Always-On Display) Changes
- **Default set to OFF**: AOD mode is now disabled by default across all entry points (`AodCustomizedScreen`, `MainActivity`, `MusicService`) instead of being enabled by default.
- **AOD Toggle in Player Menu**: The AOD menu action in the player now toggles the feature on/off (persisted preference) instead of immediately activating AOD mode. The button visually reflects the current state with a highlighted background when enabled.

## Motion Scheme
- **Global Expressive Motion**: The global `MotionScheme` in `Theme.kt` is set to `MotionScheme.expressive()` for fluid, bouncing elastic transitions throughout the app.
- **V9 Playback Controls**: `V9AnimatedPlaybackControls` uses `MotionScheme.standard()` locally for its spatial animation specs to prevent over-bouncy button behavior.

## MusicService Fixes
- Registered the media session with the service via `addSession(mediaSession)` to fix the Android system media player card not appearing in the notification shade / quick settings.

## yt-dlp Performance Optimization
- **Fast-path audio metadata extraction**: Added a two-pass extraction strategy — first tries a fast extraction skipping `initial_data` with diagnostics disabled, and falls back to a full extraction only if required metadata (title, duration, thumbnail) is missing or the fast path fails.
- Extracted `_extract_audio_info` helper and `_has_required_song_metadata` check for cleaner control flow.

## Developer Options (Nightly Builds)
- **Gated LeakCanary System**: Implemented manual watchers in nightly configurations to allow toggling LeakCanary dynamically under Developer Options.
  - Disabled auto-installer to prevent startup performance hiccups.
  - Removed duplicate home screen launcher icon, replacing it with a clean long-press dynamic shortcut.
  - Minor formatting cleanup in `LeakCanaryVariant.kt`.

## MainActivity BottomSheet Sync
- Reformatted status bar hiding condition for V7 player design style for readability (no behavioral change).
