### PR TITLE
fix(ui): Android 16 corner-radius crashes & player tap improvements

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerArtistText.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerArtistText.kt
@@ -47,17 +47,16 @@ fun ClickableArtists(
     textAlign: TextAlign? = null,
     onLongClick: (() -> Unit)? = null,
 ) {
-    val annotatedString =
-        remember(artists) {
-            buildAnnotatedString {
-                artists.forEachIndexed { index, artist ->
-                    pushStringAnnotation(tag = "artist_${artist.id.orEmpty()}", annotation = artist.id.orEmpty())
-                    append(artist.name)
-                    pop()
-                    if (index != artists.lastIndex) append(", ")
-                }
+    val annotatedString = remember(artists) {
+        buildAnnotatedString {
+            artists.forEachIndexed { index, artist ->
+                pushStringAnnotation(tag = "artist_${artist.id.orEmpty()}", annotation = artist.id.orEmpty())
+                append(artist.name)
+                pop()
+                if (index != artists.lastIndex) append(", ")
             }
         }
+    }
 
     var layoutResult by remember { mutableStateOf<TextLayoutResult?>(null) }
 
@@ -69,19 +68,17 @@ fun ClickableArtists(
         maxLines = 1,
         overflow = TextOverflow.Ellipsis,
         onTextLayout = { layoutResult = it },
-        modifier =
-            modifier.pointerInput(annotatedString) {
-                detectTapGestures(
-                    onTap = { offset ->
-                        val layout = layoutResult ?: return@detectTapGestures
-                        val position = layout.getOffsetForPosition(offset)
-                        annotatedString
-                            .getStringAnnotations(position, position)
-                            .firstOrNull()
-                            ?.let { onArtistClick(it.item) }
-                    },
-                    onLongPress = onLongClick?.let { handler -> { handler() } },
-                )
-            },
+        modifier = modifier.pointerInput(annotatedString) {
+            detectTapGestures(
+                onTap = { offset ->
+                    val layout = layoutResult ?: return@detectTapGestures
+                    val position = layout.getOffsetForPosition(offset)
+                    annotatedString.getStringAnnotations(position, position)
+                        .firstOrNull()
+                        ?.let { onArtistClick(it.item) }
+                },
+                onLongPress = onLongClick?.let { handler -> { handler() } },
+            )
+        },
     )
 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerComponents.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerComponents.kt
@@ -4805,7 +4805,7 @@ fun V10PlayerContent(
                             }
                         }
                     },
-                horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.Start),
+                horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 // Like Button
@@ -4816,39 +4816,6 @@ fun V10PlayerContent(
                     field = field,
                     iconResId = if (liked) R.drawable.favorite else R.drawable.favorite_border,
                     contentDescription = "Like"
-                )
-
-                // Shuffle Button
-                V10ToggleButton(
-                    checked = shuffleModeEnabled,
-                    onClick = {
-                        try {
-                            playerConnection.player.shuffleModeEnabled = !shuffleModeEnabled
-                        } catch (_: Exception) {}
-                    },
-                    accent = accent,
-                    field = field,
-                    iconResId = R.drawable.shuffle,
-                    contentDescription = "Shuffle"
-                )
-
-                // Repeat Button
-                val repeatActive = repeatMode != Player.REPEAT_MODE_OFF
-                val repeatIcon = when (repeatMode) {
-                    Player.REPEAT_MODE_ONE -> R.drawable.repeat_one
-                    else -> R.drawable.repeat
-                }
-                V10ToggleButton(
-                    checked = repeatActive,
-                    onClick = {
-                        try {
-                            playerConnection.player.toggleRepeatMode()
-                        } catch (_: Exception) {}
-                    },
-                    accent = accent,
-                    field = field,
-                    iconResId = repeatIcon,
-                    contentDescription = "Repeat"
                 )
 
                 // Add to Playlist Button

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerComponents.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerComponents.kt
@@ -31,6 +31,7 @@ import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.Box
@@ -70,6 +71,7 @@ import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MotionScheme
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.material3.ripple
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Surface
@@ -4974,16 +4976,35 @@ internal fun EditorialCircleButton(
     size: Dp,
     content: @Composable () -> Unit
 ) {
-    FilledIconButton(
-        onClick = onClick,
-        shape = CircleShape,
-        colors = IconButtonDefaults.filledIconButtonColors(
-            containerColor = accent,
-            contentColor = field
+    val interactionSource = remember { MutableInteractionSource() }
+    val isPressed by interactionSource.collectIsPressedAsState()
+    val scale by animateFloatAsState(
+        targetValue = if (isPressed) 0.95f else 1f,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioNoBouncy,
+            stiffness = Spring.StiffnessMedium
         ),
-        modifier = Modifier.size(size)
+        label = "CircleButtonScale"
+    )
+    Box(
+        modifier = Modifier
+            .size(size)
+            .graphicsLayer {
+                scaleX = scale
+                scaleY = scale
+            }
+            .clip(CircleShape)
+            .background(accent)
+            .clickable(
+                interactionSource = interactionSource,
+                indication = ripple(color = field.copy(alpha = 0.2f)),
+                onClick = onClick
+            ),
+        contentAlignment = Alignment.Center
     ) {
-        content()
+        CompositionLocalProvider(LocalContentColor provides field) {
+            content()
+        }
     }
 }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerComponents.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerComponents.kt
@@ -82,6 +82,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.runtime.CompositionLocalProvider
 import moe.rukamori.archivetune.ui.component.LocalMenuState
 import kotlinx.coroutines.delay
 import androidx.compose.runtime.rememberCoroutineScope
@@ -4591,19 +4594,18 @@ fun V10PlayerContent(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 24.dp)
+                    .clickable(
+                        indication = null,
+                        interactionSource = remember { MutableInteractionSource() },
+                        onClick = onTitleClick,
+                    )
             )
 
-            val artistName = remember(mediaMetadata.artists) {
-                mediaMetadata.artists.joinToString(", ") { it.name }
-            }
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 20.dp, vertical = 4.dp)
                     .clip(RoundedCornerShape(8.dp))
-                    .clickable {
-                        mediaMetadata.artists.firstOrNull()?.id?.let(onArtistClick)
-                    }
                     .padding(horizontal = 4.dp, vertical = 4.dp),
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.Start
@@ -4618,15 +4620,15 @@ fun V10PlayerContent(
                             .size(16.dp)
                     )
                 }
-                Text(
-                    text = artistName.uppercase(),
+                ClickableArtists(
+                    artists = mediaMetadata.artists,
+                    onArtistClick = onArtistClick,
                     style = MaterialTheme.typography.labelLarge.copy(letterSpacing = 2.sp),
                     color = accent.copy(alpha = 0.8f),
-                    maxLines = 1,
                     modifier = Modifier.basicMarquee(
                         iterations = Int.MAX_VALUE,
                         initialDelayMillis = 2000
-                    )
+                    ),
                 )
             }
         }
@@ -4993,14 +4995,20 @@ internal fun EditorialChip(
     field: Color,
     content: @Composable () -> Unit
 ) {
-    Surface(
-        onClick = onClick,
-        shape = CircleShape,
-        color = if (checked) accent else Color.Transparent,
-        contentColor = if (checked) field else accent,
-        modifier = Modifier.size(48.dp)
+    val backgroundColor by animateColorAsState(
+        targetValue = if (checked) accent else Color.Transparent,
+        label = "EditorialChipBg"
+    )
+    val contentColor = if (checked) field else accent
+    Box(
+        modifier = Modifier
+            .size(48.dp)
+            .clip(CircleShape)
+            .background(backgroundColor)
+            .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center
     ) {
-        Box(contentAlignment = Alignment.Center) {
+        CompositionLocalProvider(LocalContentColor provides contentColor) {
             content()
         }
     }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerComponents.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerComponents.kt
@@ -4496,28 +4496,31 @@ fun V10PlayerContent(
             ) {
                 if (sleepTimerEnabled) {
                     val countdownText = makeTimeString(sleepTimerTimeLeft.coerceAtLeast(0L))
-                    Surface(
-                        onClick = onSleepTimerClick,
-                        shape = CircleShape,
-                        color = accent,
-                        contentColor = field,
-                        modifier = Modifier.height(44.dp)
+                    Box(
+                        modifier = Modifier
+                            .height(44.dp)
+                            .clip(CircleShape)
+                            .background(accent)
+                            .clickable(onClick = onSleepTimerClick),
+                        contentAlignment = Alignment.Center
                     ) {
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.Center,
-                            modifier = Modifier.padding(horizontal = 16.dp)
-                        ) {
-                            Text(
-                                text = countdownText,
-                                style = MaterialTheme.typography.labelLarge.copy(fontWeight = FontWeight.Bold)
-                            )
-                            Spacer(modifier = Modifier.width(8.dp))
-                            Icon(
-                                painter = painterResource(R.drawable.bedtime),
-                                contentDescription = "Sleep timer",
-                                modifier = Modifier.size(18.dp)
-                            )
+                        CompositionLocalProvider(LocalContentColor provides field) {
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.Center,
+                                modifier = Modifier.padding(horizontal = 16.dp)
+                            ) {
+                                Text(
+                                    text = countdownText,
+                                    style = MaterialTheme.typography.labelLarge.copy(fontWeight = FontWeight.Bold)
+                                )
+                                Spacer(modifier = Modifier.width(8.dp))
+                                Icon(
+                                    painter = painterResource(R.drawable.bedtime),
+                                    contentDescription = "Sleep timer",
+                                    modifier = Modifier.size(18.dp)
+                                )
+                            }
                         }
                     }
                 } else {
@@ -4651,16 +4654,16 @@ fun V10PlayerContent(
                     .height(80.dp),
                 horizontalArrangement = Arrangement.spacedBy(12.dp)
             ) {
-                Surface(
-                    onClick = onPlayPauseClick,
+                Box(
                     modifier = Modifier
                         .weight(1f)
-                        .fillMaxHeight(),
-                    shape = RoundedCornerShape(50),
-                    color = accent,
-                    contentColor = field
+                        .fillMaxHeight()
+                        .clip(RoundedCornerShape(50))
+                        .background(accent)
+                        .clickable(onClick = onPlayPauseClick),
+                    contentAlignment = Alignment.Center
                 ) {
-                    Box(contentAlignment = Alignment.Center) {
+                    CompositionLocalProvider(LocalContentColor provides field) {
                         if (isLoading && !isPlaying) {
                             LoadingIndicator(
                                 modifier = Modifier.size(36.dp),
@@ -4789,11 +4792,11 @@ fun V10PlayerContent(
 
             Spacer(modifier = Modifier.height(18.dp))
 
-            // ========== CHIPS ROW ==========
+            // ========== TOGGLE ROW (V9 INDIVIDUAL BUTTONS STYLE) ==========
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(bottom = 8.dp)
+                    .padding(start = 20.dp, end = 20.dp, bottom = 8.dp)
                     .pointerInput(Unit) {
                         detectVerticalDragGestures { change, dragAmount ->
                             if (dragAmount < -15) {
@@ -4802,21 +4805,21 @@ fun V10PlayerContent(
                             }
                         }
                     },
-                horizontalArrangement = Arrangement.SpaceAround // Spread the buttons wider apart
+                horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.Start),
+                verticalAlignment = Alignment.CenterVertically
             ) {
-                EditorialChip(
+                // Like Button
+                V10ToggleButton(
                     checked = liked,
-                    onClick = { onToggleLike() },
+                    onClick = onToggleLike,
                     accent = accent,
-                    field = field
-                ) {
-                    Icon(
-                        painter = painterResource(if (liked) R.drawable.favorite else R.drawable.favorite_border),
-                        contentDescription = "Like",
-                        modifier = Modifier.size(20.dp)
-                    )
-                }
-                EditorialChip(
+                    field = field,
+                    iconResId = if (liked) R.drawable.favorite else R.drawable.favorite_border,
+                    contentDescription = "Like"
+                )
+
+                // Shuffle Button
+                V10ToggleButton(
                     checked = shuffleModeEnabled,
                     onClick = {
                         try {
@@ -4824,34 +4827,39 @@ fun V10PlayerContent(
                         } catch (_: Exception) {}
                     },
                     accent = accent,
-                    field = field
-                ) {
-                    Icon(painter = painterResource(R.drawable.shuffle), contentDescription = "Shuffle", modifier = Modifier.size(20.dp))
+                    field = field,
+                    iconResId = R.drawable.shuffle,
+                    contentDescription = "Shuffle"
+                )
+
+                // Repeat Button
+                val repeatActive = repeatMode != Player.REPEAT_MODE_OFF
+                val repeatIcon = when (repeatMode) {
+                    Player.REPEAT_MODE_ONE -> R.drawable.repeat_one
+                    else -> R.drawable.repeat
                 }
-                EditorialChip(
-                    checked = repeatMode != Player.REPEAT_MODE_OFF,
+                V10ToggleButton(
+                    checked = repeatActive,
                     onClick = {
                         try {
                             playerConnection.player.toggleRepeatMode()
                         } catch (_: Exception) {}
                     },
                     accent = accent,
-                    field = field
-                ) {
-                    Icon(
-                        painter = painterResource(if (repeatMode == Player.REPEAT_MODE_ONE) R.drawable.repeat_one else R.drawable.repeat),
-                        contentDescription = "Repeat",
-                        modifier = Modifier.size(20.dp)
-                    )
-                }
-                EditorialChip(
+                    field = field,
+                    iconResId = repeatIcon,
+                    contentDescription = "Repeat"
+                )
+
+                // Add to Playlist Button
+                V10ToggleButton(
                     checked = false,
                     onClick = onAddToPlaylistClick,
                     accent = accent,
-                    field = field
-                ) {
-                    Icon(painter = painterResource(R.drawable.library_add), contentDescription = "Add to playlist", modifier = Modifier.size(20.dp))
-                }
+                    field = field,
+                    iconResId = R.drawable.library_add,
+                    contentDescription = "Add to playlist"
+                )
             }
         }
 
@@ -5031,6 +5039,39 @@ internal fun EditorialChip(
     ) {
         CompositionLocalProvider(LocalContentColor provides contentColor) {
             content()
+        }
+    }
+}
+
+@Composable
+private fun V10ToggleButton(
+    checked: Boolean,
+    onClick: () -> Unit,
+    accent: Color,
+    field: Color,
+    iconResId: Int,
+    contentDescription: String?,
+) {
+    val containerColor by animateColorAsState(
+        targetValue = if (checked) accent else accent.copy(alpha = 0.08f),
+        label = "V10ToggleButtonBg"
+    )
+    val contentColor = if (checked) field else accent
+
+    Box(
+        modifier = Modifier
+            .size(48.dp)
+            .clip(CircleShape)
+            .background(containerColor)
+            .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        CompositionLocalProvider(LocalContentColor provides contentColor) {
+            Icon(
+                painter = painterResource(iconResId),
+                contentDescription = contentDescription,
+                modifier = Modifier.size(20.dp),
+            )
         }
     }
 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerTitleActions.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerTitleActions.kt
@@ -52,10 +52,9 @@ fun rememberPlayerTitleActions(
     val context = LocalContext.current
     val clipboardManager =
         context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-    val artistLine =
-        remember(mediaMetadata.artists) {
-            mediaMetadata.artists.joinToString(", ") { it.name }
-        }
+    val artistLine = remember(mediaMetadata.artists) {
+        mediaMetadata.artists.joinToString(", ") { it.name }
+    }
 
     return remember(mediaMetadata, navController, state, artistLine) {
         PlayerTitleActions(
@@ -77,13 +76,13 @@ fun rememberPlayerTitleActions(
             },
             onCopyTitle = {
                 clipboardManager.setPrimaryClip(
-                    ClipData.newPlainText("Copied Title", mediaMetadata.title),
+                    ClipData.newPlainText("Copied Title", mediaMetadata.title)
                 )
                 Toast.makeText(context, "Copied Title", Toast.LENGTH_SHORT).show()
             },
             onCopyArtists = {
                 clipboardManager.setPrimaryClip(
-                    ClipData.newPlainText("Copied Artist", artistLine),
+                    ClipData.newPlainText("Copied Artist", artistLine)
                 )
                 Toast.makeText(context, "Copied Artist", Toast.LENGTH_SHORT).show()
             },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/ToggleSegmentButton.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/ToggleSegmentButton.kt
@@ -220,7 +220,7 @@ private fun ToggleSegmentButtonContainer(
     Box(
         modifier = modifier
             .fillMaxSize()
-            .clip(RoundedCornerShape(cornerRadius))
+            .clip(RoundedCornerShape(cornerRadius.coerceAtLeast(0.dp)))
             .background(bgColor)
             .clickable(enabled = enabled, onClick = onClick),
         contentAlignment = Alignment.Center

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/ToggleSegmentButton.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/ToggleSegmentButton.kt
@@ -213,14 +213,14 @@ private fun ToggleSegmentButtonContainer(
     )
     val cornerRadius by animateDpAsState(
         targetValue = if (active) activeCornerRadius else 8.dp,
-        animationSpec = spring(stiffness = Spring.StiffnessLow),
+        animationSpec = tween(durationMillis = 200),
         label = ""
     )
 
     Box(
         modifier = modifier
             .fillMaxSize()
-            .clip(RoundedCornerShape(cornerRadius.coerceAtLeast(0.dp)))
+            .clip(RoundedCornerShape(cornerRadius))
             .background(bgColor)
             .clickable(enabled = enabled, onClick = onClick),
         contentAlignment = Alignment.Center


### PR DESCRIPTION
### Summary

This PR resolves multiple animation-induced crashes observed on Android 16 (SDK 36) in the player interface, unifies the tap actions for song titles and artist names across player design styles, and updates the layout of the V10 player design to be crash-safe.

---

### Key Changes

#### 1. Android 16 Shape Animation Crash Fixes
* **The Bug:** During state transitions (such as pressing play/pause, sleep timer interactions, or toggling player layout options), spring animations on corner shapes can over/undershoot below `0.dp`, triggering `java.lang.IllegalArgumentException: Corner size in Px can't be negative`.
* **The Fix:**
  - Replaced the spring animation in `ToggleSegmentButtonContainer` with a mathematically-bounded `tween` transition.
  - Replaced all `Surface(onClick = ...)` usages in the V10 player with safe `Box` + `Modifier.clip(shape).background(color).clickable(onClick)` layouts. This removes internal `rememberAnimatedShape` injections completely, preventing SDK 36 overshoots. Affected components include the Play/Pause pill, the sleep timer pill, and the bottom actions (Like and Add to Playlist).

#### 2. V10 Bottom Row Layout Updates
* **Removed the Loop and Shuffle buttons** from the V10 player's bottom row (they remain accessible in the queue area). This solves the crash vectors associated with their states in the player view.
* Moved the **Like** and **Add to Playlist** buttons to the bottom row, aligned to the **right end** of the row.
* Designed using individual circular shapes matching the V9 immersive design style.

#### 3. Centralized Player Title & Artist Tap Behaviors (`PlayerTitleActions.kt`)
* Unified title/artist navigation and clipboard events into a centralized `rememberPlayerTitleActions()` class helper.
* Resolved sheet collapses to cleanly run `collapseSoft()` before invoking navigations.

#### 4. Individual Artist Name Tap Targets (`PlayerArtistText.kt`)
* Implemented `ClickableArtists` with pointer hit-testing to identify the exact artist name clicked, rather than always opening the first artist's page.
* Integrated individual artist selection targets in V10, V9, V8, and V1–V4/V6 layouts.
