### PR TITLE
fix(Updater): use dynamic release URLs for nightly builds

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -126,6 +126,17 @@ android {
         buildConfigField("String", "GITHUB_OWNER", githubOwner.asBuildConfigString())
         buildConfigField("String", "GITHUB_REPO", githubRepo.asBuildConfigString())
         buildConfigField("boolean", "IS_NIGHTLY_BUILD", "false")
+
+        val releaseGithubOwner =
+            System.getenv("RELEASE_GITHUB_OWNER")?.trim()
+                ?: localProperties.getProperty("RELEASE_GITHUB_OWNER")?.trim()
+                ?: githubOwner
+        val releaseGithubRepo =
+            System.getenv("RELEASE_GITHUB_REPO")?.trim()
+                ?: localProperties.getProperty("RELEASE_GITHUB_REPO")?.trim()
+                ?: githubRepo
+        buildConfigField("String", "RELEASE_GITHUB_OWNER", releaseGithubOwner.asBuildConfigString())
+        buildConfigField("String", "RELEASE_GITHUB_REPO", releaseGithubRepo.asBuildConfigString())
     }
 
     flavorDimensions += listOf("distribution", "device", "abi")
@@ -226,6 +237,17 @@ android {
             buildConfigField("boolean", "LEAK_CANARY_TOGGLE_AVAILABLE", "true")
             buildConfigField("boolean", "IS_NIGHTLY_BUILD", "true")
             matchingFallbacks += listOf("release")
+
+            val nightlyReleaseOwner =
+                System.getenv("NIGHTLY_RELEASE_GITHUB_OWNER")?.trim()
+                    ?: localProperties.getProperty("NIGHTLY_RELEASE_GITHUB_OWNER")?.trim()
+                    ?: "rukamori"
+            val nightlyReleaseRepo =
+                System.getenv("NIGHTLY_RELEASE_GITHUB_REPO")?.trim()
+                    ?: localProperties.getProperty("NIGHTLY_RELEASE_GITHUB_REPO")?.trim()
+                    ?: "canary"
+            buildConfigField("String", "RELEASE_GITHUB_OWNER", nightlyReleaseOwner.asBuildConfigString())
+            buildConfigField("String", "RELEASE_GITHUB_REPO", nightlyReleaseRepo.asBuildConfigString())
         }
     }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/UpdateScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/UpdateScreen.kt
@@ -324,6 +324,9 @@ fun UpdateScreen(
                             if (updateSheetIsSameVersion) {
                                 showUpdateUpToDateDialog = true
                                 onUpToDate()
+                            } else if (updateChannel == UpdateChannel.ARTIFACT) {
+                                val downloadUrl = Updater.getLatestCanaryDownloadUrl()
+                                installUpdate(downloadUrl)
                             } else {
                                 updateSheetState.show(updateSheetContent)
                             }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/utils/Updater.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/utils/Updater.kt
@@ -55,15 +55,20 @@ private data class ReleasesNetworkResult(
 object Updater {
     private val client = HttpClient()
     private const val ReleaseCacheCheckIntervalMs: Long = 6 * 60 * 60 * 1000L
-    private const val CommitHistoryBaseUrl = "https://api.github.com/repos/rukamori/ArchiveTune"
 
     private val githubOwner: String
         get() = BuildConfig.GITHUB_OWNER
     private val githubRepo: String
         get() = BuildConfig.GITHUB_REPO
+    private val releaseOwner: String
+        get() = BuildConfig.RELEASE_GITHUB_OWNER
+    private val releaseRepo: String
+        get() = BuildConfig.RELEASE_GITHUB_REPO
+
+    private const val CommitHistoryBaseUrl = "https://api.github.com/repos/rukamori/ArchiveTune"
 
     private val stableReleaseBaseUrl: String
-        get() = "https://github.com/$githubOwner/$githubRepo/releases"
+        get() = "https://github.com/$releaseOwner/$releaseRepo/releases"
     private val artifactWorkflowRunsUrl: String
         get() = "https://api.github.com/repos/$githubOwner/$githubRepo/actions/workflows/build.yml/runs" +
             "?branch=dev&status=success&per_page=1&exclude_pull_requests=true"
@@ -93,7 +98,11 @@ object Updater {
             }
 
     private fun stableReleaseArtifactName(): String =
-        "app-$releaseArtifactPrefix${BuildConfig.DEVICE}-${BuildConfig.ARCHITECTURE}-release.apk"
+        if (BuildConfig.IS_NIGHTLY_BUILD) {
+            "app-$releaseArtifactPrefix${BuildConfig.DEVICE}-${BuildConfig.ARCHITECTURE}-nightly.apk"
+        } else {
+            "app-$releaseArtifactPrefix${BuildConfig.DEVICE}-${BuildConfig.ARCHITECTURE}-release.apk"
+        }
 
     private fun artifactReleaseArtifactName(): String =
         "app-$releaseArtifactPrefix${BuildConfig.DEVICE}-${BuildConfig.ARCHITECTURE}-release"
@@ -245,10 +254,10 @@ object Updater {
 
     internal fun findLatestCanaryRelease(releases: List<ReleaseInfo>): ReleaseInfo? {
         if (releases.isEmpty()) return null
-        return releases.maxByOrNull { release ->
+        return releases.maxWithOrNull(compareByDescending<ReleaseInfo> { release ->
             val dateTag = release.tagName.removePrefix("N").takeWhile { it.isDigit() }
             dateTag.toLongOrNull() ?: 0L
-        }
+        }.thenByDescending { it.publishedAt })
     }
 
     private fun preferredReleaseVersionNameOrNull(release: ReleaseInfo): String? =
@@ -327,7 +336,7 @@ object Updater {
         cachedEtag: String?,
     ): ReleasesNetworkResult {
         val response: HttpResponse =
-            client.get("https://api.github.com/repos/$githubOwner/$githubRepo/releases?per_page=$perPage") {
+            client.get("https://api.github.com/repos/$releaseOwner/$releaseRepo/releases?per_page=$perPage") {
                 headers {
                     append("Accept", "application/vnd.github+json")
                     append("User-Agent", "ArchiveTune")
@@ -559,13 +568,12 @@ object Updater {
             workflowRun
                 .optString("run_started_at")
                 .ifBlank { workflowRun.optString("created_at") }
-        val date = publishedAt.take(10).filter(Char::isDigit)
-        if (date.length != 8) return null
+        val headSha = workflowRun.optString("head_sha", "").take(7)
+        if (headSha.isBlank()) return null
 
-        val tagName = "N$date"
         return ReleaseInfo(
-            tagName = tagName,
-            name = tagName,
+            tagName = headSha,
+            name = headSha,
             body = null,
             publishedAt = publishedAt,
             htmlUrl = workflowRun.optString("html_url"),


### PR DESCRIPTION
## Summary

- Add `RELEASE_GITHUB_OWNER`/`RELEASE_GITHUB_REPO` BuildConfig fields separate from `GITHUB_OWNER`/`GITHUB_REPO`
- Nightly builds override these to `rukamori`/ `canary` so stable channel checks the correct release repo
- Artifact channel stays on `rukamori`/`ArchiveTune` build.yml workflow artifacts
- Fix `stableReleaseArtifactName()` to return `-nightly.apk` suffix for nightly builds (matching canary workflow's APK naming)
- Artifact channel shows commit SHA (e.g. `928ac1d`) instead of `N{date}` format
- Skip update available dialog for Artifact channel, download directly

## Problem

After PR #1252, nightly builds (IS_NIGHTLY_BUILD=true) still used `rukamori/ArchiveTune` for stable release checks. The canary repo (`rukamori/canary`) hosts nightly releases with different APK naming (`-nightly.apk` vs `-release.apk`), so:

1. Stable channel checked wrong repo for nightly builds
2. Asset name mismatch caused download URLs to be null

## Changes

| File | Change |
|------|--------|
| `build.gradle.kts` | Added `RELEASE_GITHUB_OWNER`/`RELEASE_GITHUB_REPO` fields; nightly overrides to `rukamori`/`canary` |
| `Updater.kt` | `releaseOwner`/`releaseRepo` for stable URLs; nightly artifact name; artifact shows SHA |
| `UpdateScreen.kt` | Skip update dialog for Artifact channel, download directly |

## Behavior

| Build | Stable channel | Artifact channel |
|-------|---------------|-----------------|
| Regular | `rukamori/ArchiveTune/releases` + `-release.apk` | `rukamori/ArchiveTune` build.yml → SHA → direct download |
| Nightly | `rukamori/canary/releases` + `-nightly.apk` | `rukamori/ArchiveTune` build.yml → SHA → direct download |

All values overridable via env vars or `local.properties` for forks.