### PR TITLE
feat(ui): implement continuous shape morphing for MiniPlayer and NavBar

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -1046,11 +1046,12 @@ class MainActivity : ComponentActivity() {
                     val floatingBarsBottomPadding = NavigationBarBottomPadding
                     val navVisibleHeight = NavigationBarHeight
 
-                    val bottomNavigationBarHeight by animateDpAsState(
+                    val bottomNavigationBarHeightState = animateDpAsState(
                         targetValue = if (shouldShowNavigationBar && !useRail) navVisibleHeight else 0.dp,
                         animationSpec = if (disableAnimations) snap() else NavigationBarAnimationSpec,
                         label = "",
                     )
+                    val bottomNavigationBarHeight by bottomNavigationBarHeightState
 
                     val playerBottomSheetState =
                         rememberBottomSheetState(
@@ -2130,38 +2131,50 @@ class MainActivity : ComponentActivity() {
                                 },
                                 bottomBar = {
                                     Box {
-                                        val navRatio =
-                                            (bottomNavigationBarHeight / navVisibleHeight).coerceIn(0f, 1f)
-                                        val isNavTransitioning =
-                                            bottomNavigationBarHeight > 0.dp && bottomNavigationBarHeight < navVisibleHeight
-                                        // Threshold matches physical travel needed on dismiss for MiniPlayer's top edge
-                                        // to align flush with NavBar's top edge (MiniPlayerHeight + MiniPlayerBottomSpacing = 74dp).
-                                        val morphThreshold = MiniPlayerHeight + MiniPlayerBottomSpacing
-                                        val swipeDeviation =
-                                            if (isNavTransitioning && playerBottomSheetState.targetAnchor == COLLAPSED_ANCHOR) {
-                                                0.dp
-                                            } else {
-                                                playerBottomSheetState.value.let { v ->
-                                                    if (v < playerBottomSheetState.collapsedBound) {
-                                                        playerBottomSheetState.collapsedBound - v
+                                        // All per-frame inputs (sheet drag value, navbar spring) are read inside this
+                                        // provider, which is only consumed in the draw phase (graphicsLayer) or behind
+                                        // derivedStateOf. The bottomBar scope and the player/miniplayer/toolbar chain
+                                        // therefore never recompose during drag or navigation morphs.
+                                        val showNavigationBarState = rememberUpdatedState(shouldShowNavigationBar)
+                                        val useRailState = rememberUpdatedState(useRail)
+                                        val navigationProximityProvider: () -> Float =
+                                            remember(playerBottomSheetState, bottomNavigationBarHeightState) {
+                                                {
+                                                    val navRatio =
+                                                        (bottomNavigationBarHeightState.value / navVisibleHeight).coerceIn(0f, 1f)
+                                                    val isNavTransitioning =
+                                                        bottomNavigationBarHeightState.value > 0.dp &&
+                                                            bottomNavigationBarHeightState.value < navVisibleHeight
+                                                    // Threshold matches physical travel needed on dismiss for MiniPlayer's
+                                                    // top edge to align flush with NavBar's top edge
+                                                    // (MiniPlayerHeight + MiniPlayerBottomSpacing = 74dp).
+                                                    val morphThreshold = MiniPlayerHeight + MiniPlayerBottomSpacing
+                                                    val swipeDeviation =
+                                                        if (isNavTransitioning && playerBottomSheetState.targetAnchor == COLLAPSED_ANCHOR) {
+                                                            0.dp
+                                                        } else {
+                                                            playerBottomSheetState.value.let { v ->
+                                                                if (v < playerBottomSheetState.collapsedBound) {
+                                                                    playerBottomSheetState.collapsedBound - v
+                                                                } else {
+                                                                    v - playerBottomSheetState.collapsedBound
+                                                                }
+                                                            }
+                                                        }
+                                                    val sheetPresence = (1f - (swipeDeviation / morphThreshold)).coerceIn(0f, 1f)
+                                                    if (!showNavigationBarState.value || useRailState.value) {
+                                                        0f
                                                     } else {
-                                                        v - playerBottomSheetState.collapsedBound
+                                                        navRatio * sheetPresence
                                                     }
                                                 }
-                                            }
-                                        val sheetPresence = (1f - (swipeDeviation / morphThreshold)).coerceIn(0f, 1f)
-                                        val navigationProximity =
-                                            if (!shouldShowNavigationBar || useRail) {
-                                                0f
-                                            } else {
-                                                navRatio * sheetPresence
                                             }
 
                                         BottomSheetPlayer(
                                             state = playerBottomSheetState,
                                             navController = navController,
                                             pureBlack = pureBlack,
-                                            navigationProximity = navigationProximity,
+                                            navigationProximityProvider = navigationProximityProvider,
                                         )
 
                                         if (useRail) return@Box
@@ -2204,7 +2217,7 @@ class MainActivity : ComponentActivity() {
                                             FloatingNavigationToolbar(
                                                 items = navigationItems,
                                                 pureBlack = pureBlack,
-                                                miniPlayerProximity = navigationProximity,
+                                                miniPlayerProximityProvider = navigationProximityProvider,
                                                 modifier =
                                                     Modifier
                                                         .align(Alignment.BottomCenter)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -2131,10 +2131,6 @@ class MainActivity : ComponentActivity() {
                                 },
                                 bottomBar = {
                                     Box {
-                                        // All per-frame inputs (sheet drag value, navbar spring) are read inside this
-                                        // provider, which is only consumed in the draw phase (graphicsLayer) or behind
-                                        // derivedStateOf. The bottomBar scope and the player/miniplayer/toolbar chain
-                                        // therefore never recompose during drag or navigation morphs.
                                         val showNavigationBarState = rememberUpdatedState(shouldShowNavigationBar)
                                         val useRailState = rememberUpdatedState(useRail)
                                         val navigationProximityProvider: () -> Float =
@@ -2145,9 +2141,6 @@ class MainActivity : ComponentActivity() {
                                                     val isNavTransitioning =
                                                         bottomNavigationBarHeightState.value > 0.dp &&
                                                             bottomNavigationBarHeightState.value < navVisibleHeight
-                                                    // Threshold matches physical travel needed on dismiss for MiniPlayer's
-                                                    // top edge to align flush with NavBar's top edge
-                                                    // (MiniPlayerHeight + MiniPlayerBottomSpacing = 74dp).
                                                     val morphThreshold = MiniPlayerHeight + MiniPlayerBottomSpacing
                                                     val swipeDeviation =
                                                         if (isNavTransitioning && playerBottomSheetState.targetAnchor == COLLAPSED_ANCHOR) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -2130,32 +2130,29 @@ class MainActivity : ComponentActivity() {
                                 },
                                 bottomBar = {
                                     Box {
+                                        val navRatio =
+                                            (bottomNavigationBarHeight / navVisibleHeight).coerceIn(0f, 1f)
+                                        val isNavTransitioning =
+                                            bottomNavigationBarHeight > 0.dp && bottomNavigationBarHeight < navVisibleHeight
+                                        val morphThreshold = MiniPlayerHeight + MiniPlayerBottomSpacing
+                                        val swipeDeviation =
+                                            if (isNavTransitioning) {
+                                                0.dp
+                                            } else {
+                                                playerBottomSheetState.value.let { v ->
+                                                    if (v < playerBottomSheetState.collapsedBound) {
+                                                        playerBottomSheetState.collapsedBound - v
+                                                    } else {
+                                                        v - playerBottomSheetState.collapsedBound
+                                                    }
+                                                }
+                                            }
+                                        val sheetPresence = (1f - (swipeDeviation / morphThreshold)).coerceIn(0f, 1f)
                                         val navigationProximity =
                                             if (!shouldShowNavigationBar || useRail) {
                                                 0f
                                             } else {
-                                                val navRatio =
-                                                    (bottomNavigationBarHeight / navVisibleHeight)
-                                                        .coerceIn(0f, 1f)
-                                                val sheetAtRestRatio =
-                                                    with(playerBottomSheetState) {
-                                                        if (value <= collapsedBound) {
-                                                            if (collapsedBound > dismissedBound) {
-                                                                ((value - dismissedBound) / (collapsedBound - dismissedBound))
-                                                                    .coerceIn(0f, 1f)
-                                                            } else {
-                                                                0f
-                                                            }
-                                                        } else {
-                                                            if (expandedBound > collapsedBound) {
-                                                                ((expandedBound - value) / (expandedBound - collapsedBound))
-                                                                    .coerceIn(0f, 1f)
-                                                            } else {
-                                                                0f
-                                                            }
-                                                        }
-                                                    }
-                                                sheetAtRestRatio * navRatio
+                                                navRatio * sheetPresence
                                             }
 
                                         BottomSheetPlayer(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -2130,16 +2130,39 @@ class MainActivity : ComponentActivity() {
                                 },
                                 bottomBar = {
                                     Box {
-                                        val areBottomBarsPaired =
-                                            shouldShowNavigationBar &&
-                                                !useRail &&
-                                                playerBottomSheetState.isCollapsed
+                                        val navigationProximity =
+                                            if (!shouldShowNavigationBar || useRail) {
+                                                0f
+                                            } else {
+                                                val navRatio =
+                                                    (bottomNavigationBarHeight / navVisibleHeight)
+                                                        .coerceIn(0f, 1f)
+                                                val sheetAtRestRatio =
+                                                    with(playerBottomSheetState) {
+                                                        if (value <= collapsedBound) {
+                                                            if (collapsedBound > dismissedBound) {
+                                                                ((value - dismissedBound) / (collapsedBound - dismissedBound))
+                                                                    .coerceIn(0f, 1f)
+                                                            } else {
+                                                                0f
+                                                            }
+                                                        } else {
+                                                            if (expandedBound > collapsedBound) {
+                                                                ((expandedBound - value) / (expandedBound - collapsedBound))
+                                                                    .coerceIn(0f, 1f)
+                                                            } else {
+                                                                0f
+                                                            }
+                                                        }
+                                                    }
+                                                sheetAtRestRatio * navRatio
+                                            }
 
                                         BottomSheetPlayer(
                                             state = playerBottomSheetState,
                                             navController = navController,
                                             pureBlack = pureBlack,
-                                            isMiniPlayerPairedWithNavigation = areBottomBarsPaired,
+                                            navigationProximity = navigationProximity,
                                         )
 
                                         if (useRail) return@Box
@@ -2182,7 +2205,7 @@ class MainActivity : ComponentActivity() {
                                             FloatingNavigationToolbar(
                                                 items = navigationItems,
                                                 pureBlack = pureBlack,
-                                                isPairedWithMiniPlayer = areBottomBarsPaired,
+                                                miniPlayerProximity = navigationProximity,
                                                 modifier =
                                                     Modifier
                                                         .align(Alignment.BottomCenter)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -2134,9 +2134,11 @@ class MainActivity : ComponentActivity() {
                                             (bottomNavigationBarHeight / navVisibleHeight).coerceIn(0f, 1f)
                                         val isNavTransitioning =
                                             bottomNavigationBarHeight > 0.dp && bottomNavigationBarHeight < navVisibleHeight
+                                        // Threshold matches physical travel needed on dismiss for MiniPlayer's top edge
+                                        // to align flush with NavBar's top edge (MiniPlayerHeight + MiniPlayerBottomSpacing = 74dp).
                                         val morphThreshold = MiniPlayerHeight + MiniPlayerBottomSpacing
                                         val swipeDeviation =
-                                            if (isNavTransitioning) {
+                                            if (isNavTransitioning && playerBottomSheetState.targetAnchor == COLLAPSED_ANCHOR) {
                                                 0.dp
                                             } else {
                                                 playerBottomSheetState.value.let { v ->

--- a/app/src/main/kotlin/moe/rukamori/archivetune/constants/Dimensions.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/constants/Dimensions.kt
@@ -25,6 +25,9 @@ val NavigationBarMaxWidth = 420.dp
 val NavigationBarHeight = 78.dp
 val MiniPlayerHeight = 70.dp
 val MiniPlayerBottomSpacing = 4.dp
+val FloatingBarStandaloneCornerRadius = 32.dp
+val FloatingBarOuterCornerRadius = 28.dp
+val FloatingBarJunctionCornerRadius = 12.dp
 val QueuePeekHeight = 64.dp
 val AppBarHeight = 64.dp
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
@@ -61,11 +61,15 @@ fun FloatingNavigationToolbar(
     items: List<Screens>,
     pureBlack: Boolean,
     modifier: Modifier = Modifier,
-    miniPlayerProximity: Float = 0f,
+    miniPlayerProximityProvider: () -> Float = { 0f },
     isSelected: (Screens) -> Boolean,
     onItemClick: (Screens, Boolean) -> Unit,
     onSearchItemDoubleClick: (() -> Unit)? = null,
 ) {
+    // Read at the leaf: the toolbar scope is the smallest unit that must recompose during the
+    // navigation spring; the bottomBar scope above stays skipped. Read once per frame and
+    // reuse for all four corners.
+    val miniPlayerProximity = miniPlayerProximityProvider()
     val navigationShape =
         RoundedCornerShape(
             topStart = lerp(FloatingBarStandaloneCornerRadius.value, FloatingBarJunctionCornerRadius.value, miniPlayerProximity).dp,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
@@ -66,9 +66,6 @@ fun FloatingNavigationToolbar(
     onItemClick: (Screens, Boolean) -> Unit,
     onSearchItemDoubleClick: (() -> Unit)? = null,
 ) {
-    // Read at the leaf: the toolbar scope is the smallest unit that must recompose during the
-    // navigation spring; the bottomBar scope above stays skipped. Read once per frame and
-    // reuse for all four corners.
     val miniPlayerProximity = miniPlayerProximityProvider()
     val navigationShape =
         RoundedCornerShape(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
@@ -46,6 +46,9 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.lerp
+import moe.rukamori.archivetune.constants.FloatingBarJunctionCornerRadius
+import moe.rukamori.archivetune.constants.FloatingBarOuterCornerRadius
+import moe.rukamori.archivetune.constants.FloatingBarStandaloneCornerRadius
 import moe.rukamori.archivetune.constants.NavigationBarHeight
 import moe.rukamori.archivetune.constants.NavigationBarMaxWidth
 import moe.rukamori.archivetune.ui.screens.Screens
@@ -65,10 +68,10 @@ fun FloatingNavigationToolbar(
 ) {
     val navigationShape =
         RoundedCornerShape(
-            topStart = lerp(32f, 12f, miniPlayerProximity).dp,
-            topEnd = lerp(32f, 12f, miniPlayerProximity).dp,
-            bottomStart = lerp(32f, 28f, miniPlayerProximity).dp,
-            bottomEnd = lerp(32f, 28f, miniPlayerProximity).dp,
+            topStart = lerp(FloatingBarStandaloneCornerRadius.value, FloatingBarJunctionCornerRadius.value, miniPlayerProximity).dp,
+            topEnd = lerp(FloatingBarStandaloneCornerRadius.value, FloatingBarJunctionCornerRadius.value, miniPlayerProximity).dp,
+            bottomStart = lerp(FloatingBarStandaloneCornerRadius.value, FloatingBarOuterCornerRadius.value, miniPlayerProximity).dp,
+            bottomEnd = lerp(FloatingBarStandaloneCornerRadius.value, FloatingBarOuterCornerRadius.value, miniPlayerProximity).dp,
         )
     val navigationContainerColor =
         if (pureBlack) Color.Black else MaterialTheme.colorScheme.surfaceContainer

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.util.lerp
 import moe.rukamori.archivetune.constants.NavigationBarHeight
 import moe.rukamori.archivetune.constants.NavigationBarMaxWidth
 import moe.rukamori.archivetune.ui.screens.Screens
@@ -57,24 +58,18 @@ fun FloatingNavigationToolbar(
     items: List<Screens>,
     pureBlack: Boolean,
     modifier: Modifier = Modifier,
-    isPairedWithMiniPlayer: Boolean = false,
+    miniPlayerProximity: Float = 0f,
     isSelected: (Screens) -> Boolean,
     onItemClick: (Screens, Boolean) -> Unit,
     onSearchItemDoubleClick: (() -> Unit)? = null,
 ) {
     val navigationShape =
-        remember(isPairedWithMiniPlayer) {
-            if (isPairedWithMiniPlayer) {
-                RoundedCornerShape(
-                    topStart = 12.dp,
-                    topEnd = 12.dp,
-                    bottomStart = 28.dp,
-                    bottomEnd = 28.dp,
-                )
-            } else {
-                null
-            }
-        } ?: MaterialTheme.shapes.extraLarge
+        RoundedCornerShape(
+            topStart = lerp(32f, 12f, miniPlayerProximity).dp,
+            topEnd = lerp(32f, 12f, miniPlayerProximity).dp,
+            bottomStart = lerp(32f, 28f, miniPlayerProximity).dp,
+            bottomEnd = lerp(32f, 28f, miniPlayerProximity).dp,
+        )
     val navigationContainerColor =
         if (pureBlack) Color.Black else MaterialTheme.colorScheme.surfaceContainer
     val motionScheme = MaterialTheme.motionScheme

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/MiniPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/MiniPlayer.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.util.lerp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.palette.graphics.Palette
 import coil3.imageLoader
@@ -61,14 +62,14 @@ fun MiniPlayer(
     duration: Long,
     modifier: Modifier = Modifier,
     pureBlack: Boolean,
-    isPairedWithNavigation: Boolean = false,
+    navigationProximity: Float = 0f,
 ) {
     NewMiniPlayer(
         position = position,
         duration = duration,
         modifier = modifier,
         pureBlack = pureBlack,
-        isPairedWithNavigation = isPairedWithNavigation,
+        navigationProximity = navigationProximity,
     )
 }
 
@@ -78,7 +79,7 @@ private fun NewMiniPlayer(
     duration: Long,
     modifier: Modifier = Modifier,
     pureBlack: Boolean,
-    isPairedWithNavigation: Boolean,
+    navigationProximity: Float,
 ) {
     val playerConnection = LocalPlayerConnection.current ?: return
     val context = LocalContext.current
@@ -179,22 +180,16 @@ private fun NewMiniPlayer(
             useArtworkBackground = effectiveBackgroundStyle != MiniPlayerBackgroundStyle.THEME,
         )
     val miniPlayerShape =
-        remember(isPairedWithNavigation) {
-            if (isPairedWithNavigation) {
-                RoundedCornerShape(
-                    topStart = 28.dp,
-                    topEnd = 28.dp,
-                    bottomStart = 12.dp,
-                    bottomEnd = 12.dp,
-                )
-            } else {
-                null
-            }
-        } ?: MaterialTheme.shapes.extraLarge
+        RoundedCornerShape(
+            topStart = lerp(32f, 28f, navigationProximity).dp,
+            topEnd = lerp(32f, 28f, navigationProximity).dp,
+            bottomStart = lerp(32f, 12f, navigationProximity).dp,
+            bottomEnd = lerp(32f, 12f, navigationProximity).dp,
+        )
 
     SwipeableMiniPlayerBox(
         modifier = modifier,
-        contentMaxWidth = if (isPairedWithNavigation) NavigationBarMaxWidth else null,
+        contentMaxWidth = if (navigationProximity > 0f) NavigationBarMaxWidth else null,
         swipeSensitivity = swipeSensitivity,
         swipeThumbnail = swipeThumbnail,
         playerConnection = playerConnection,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/MiniPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/MiniPlayer.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -65,14 +66,14 @@ fun MiniPlayer(
     duration: Long,
     modifier: Modifier = Modifier,
     pureBlack: Boolean,
-    navigationProximity: Float = 0f,
+    navigationProximityProvider: () -> Float = { 0f },
 ) {
     NewMiniPlayer(
         position = position,
         duration = duration,
         modifier = modifier,
         pureBlack = pureBlack,
-        navigationProximity = navigationProximity,
+        navigationProximityProvider = navigationProximityProvider,
     )
 }
 
@@ -82,7 +83,7 @@ private fun NewMiniPlayer(
     duration: Long,
     modifier: Modifier = Modifier,
     pureBlack: Boolean,
-    navigationProximity: Float,
+    navigationProximityProvider: () -> Float,
 ) {
     val playerConnection = LocalPlayerConnection.current ?: return
     val context = LocalContext.current
@@ -182,17 +183,25 @@ private fun NewMiniPlayer(
         rememberMiniPlayerContentColors(
             useArtworkBackground = effectiveBackgroundStyle != MiniPlayerBackgroundStyle.THEME,
         )
+    // The proximity provider is read here, at the leaf: only this scope recomposes while the
+    // MiniPlayer drags, so the bottomBar/Player chain above stays skipped. Read once per frame
+    // and reuse for all four corners. (The width constraint is a layout concern, and
+    // derivedStateOf re-composes it only when the threshold crosses zero.)
+    val proximity = navigationProximityProvider()
     val miniPlayerShape =
         RoundedCornerShape(
-            topStart = lerp(FloatingBarStandaloneCornerRadius.value, FloatingBarOuterCornerRadius.value, navigationProximity).dp,
-            topEnd = lerp(FloatingBarStandaloneCornerRadius.value, FloatingBarOuterCornerRadius.value, navigationProximity).dp,
-            bottomStart = lerp(FloatingBarStandaloneCornerRadius.value, FloatingBarJunctionCornerRadius.value, navigationProximity).dp,
-            bottomEnd = lerp(FloatingBarStandaloneCornerRadius.value, FloatingBarJunctionCornerRadius.value, navigationProximity).dp,
+            topStart = lerp(FloatingBarStandaloneCornerRadius.value, FloatingBarOuterCornerRadius.value, proximity).dp,
+            topEnd = lerp(FloatingBarStandaloneCornerRadius.value, FloatingBarOuterCornerRadius.value, proximity).dp,
+            bottomStart = lerp(FloatingBarStandaloneCornerRadius.value, FloatingBarJunctionCornerRadius.value, proximity).dp,
+            bottomEnd = lerp(FloatingBarStandaloneCornerRadius.value, FloatingBarJunctionCornerRadius.value, proximity).dp,
         )
+    val constrainToNavigationWidth by remember {
+        derivedStateOf { navigationProximityProvider() > 0f }
+    }
 
     SwipeableMiniPlayerBox(
         modifier = modifier,
-        contentMaxWidth = if (navigationProximity > 0f) NavigationBarMaxWidth else null,
+        contentMaxWidth = if (constrainToNavigationWidth) NavigationBarMaxWidth else null,
         swipeSensitivity = swipeSensitivity,
         swipeThumbnail = swipeThumbnail,
         playerConnection = playerConnection,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/MiniPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/MiniPlayer.kt
@@ -46,6 +46,9 @@ import kotlinx.coroutines.withContext
 import moe.rukamori.archivetune.LocalPlayerConnection
 import moe.rukamori.archivetune.constants.MiniPlayerBackgroundStyle
 import moe.rukamori.archivetune.constants.MiniPlayerBackgroundStyleKey
+import moe.rukamori.archivetune.constants.FloatingBarJunctionCornerRadius
+import moe.rukamori.archivetune.constants.FloatingBarOuterCornerRadius
+import moe.rukamori.archivetune.constants.FloatingBarStandaloneCornerRadius
 import moe.rukamori.archivetune.constants.MiniPlayerHeight
 import moe.rukamori.archivetune.constants.NavigationBarMaxWidth
 import moe.rukamori.archivetune.constants.SwipeSensitivityKey
@@ -181,10 +184,10 @@ private fun NewMiniPlayer(
         )
     val miniPlayerShape =
         RoundedCornerShape(
-            topStart = lerp(32f, 28f, navigationProximity).dp,
-            topEnd = lerp(32f, 28f, navigationProximity).dp,
-            bottomStart = lerp(32f, 12f, navigationProximity).dp,
-            bottomEnd = lerp(32f, 12f, navigationProximity).dp,
+            topStart = lerp(FloatingBarStandaloneCornerRadius.value, FloatingBarOuterCornerRadius.value, navigationProximity).dp,
+            topEnd = lerp(FloatingBarStandaloneCornerRadius.value, FloatingBarOuterCornerRadius.value, navigationProximity).dp,
+            bottomStart = lerp(FloatingBarStandaloneCornerRadius.value, FloatingBarJunctionCornerRadius.value, navigationProximity).dp,
+            bottomEnd = lerp(FloatingBarStandaloneCornerRadius.value, FloatingBarJunctionCornerRadius.value, navigationProximity).dp,
         )
 
     SwipeableMiniPlayerBox(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/MiniPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/MiniPlayer.kt
@@ -183,10 +183,6 @@ private fun NewMiniPlayer(
         rememberMiniPlayerContentColors(
             useArtworkBackground = effectiveBackgroundStyle != MiniPlayerBackgroundStyle.THEME,
         )
-    // The proximity provider is read here, at the leaf: only this scope recomposes while the
-    // MiniPlayer drags, so the bottomBar/Player chain above stays skipped. Read once per frame
-    // and reuse for all four corners. (The width constraint is a layout concern, and
-    // derivedStateOf re-composes it only when the threshold crosses zero.)
     val proximity = navigationProximityProvider()
     val miniPlayerShape =
         RoundedCornerShape(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
@@ -308,7 +308,7 @@ fun BottomSheetPlayer(
     navController: NavController,
     modifier: Modifier = Modifier,
     pureBlack: Boolean,
-    isMiniPlayerPairedWithNavigation: Boolean = false,
+    navigationProximity: Float = 0f,
     canvasViewModel: CanvasPlaybackViewModel = hiltViewModel(),
 ) {
     val context = LocalContext.current
@@ -1147,7 +1147,7 @@ fun BottomSheetPlayer(
                 position = position,
                 duration = duration,
                 pureBlack = pureBlack,
-                isPairedWithNavigation = isMiniPlayerPairedWithNavigation,
+                navigationProximity = navigationProximity,
             )
         },
     ) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
@@ -308,7 +308,7 @@ fun BottomSheetPlayer(
     navController: NavController,
     modifier: Modifier = Modifier,
     pureBlack: Boolean,
-    navigationProximity: Float = 0f,
+    navigationProximityProvider: () -> Float = { 0f },
     canvasViewModel: CanvasPlaybackViewModel = hiltViewModel(),
 ) {
     val context = LocalContext.current
@@ -1147,7 +1147,7 @@ fun BottomSheetPlayer(
                 position = position,
                 duration = duration,
                 pureBlack = pureBlack,
-                navigationProximity = navigationProximity,
+                navigationProximityProvider = navigationProximityProvider,
             )
         },
     ) {


### PR DESCRIPTION
# Pull Request

Before submitting a pull request, you must attest to the following:

- [x] This pull request complies with ArchiveTune's [NO AI / NO LLM POLICY](../blob/main/CONTRIBUTING.md#no-ai--no-llm-policy).

## Summary

Replaces the discrete boolean pairing states (`isPairedWithNavigation` / `isPairedWithMiniPlayer`) between MiniPlayer and FloatingNavigationToolbar with a continuous `navigationProximity` signal. Corners now smoothly morph between their standalone (`32.dp`) and docked (`12.dp`/`28.dp`) states during sheet gestures and route-driven navigation bar transitions. Per-frame state reads are deferred to leaf composables via a stable lambda provider to prevent unnecessary recompositions of parent scopes.

## Linked Work

- Related: -

## Change Type

- [x] Feature
- [ ] Bug fix
- [x] UI / UX
- [ ] Performance / memory
- [ ] Playback / Media3
- [ ] Lyrics / provider integration
- [ ] Search / YouTube / network data
- [ ] Local library / Room database
- [ ] Widgets / notification / shortcuts
- [ ] Settings / preferences / DataStore
- [ ] Discord / Last.fm / ListenBrainz / external integration
- [ ] Localization / strings / fastlane metadata
- [ ] Build / Gradle / CI / release packaging
- [ ] Dependency update
- [ ] Documentation only

## Affected Surfaces

- [x] `:app`
- [ ] `:core`
- [ ] `:lyrics`
- [ ] `:lastfm`
- [ ] `:canvas`
- [ ] `:shazamkit`
- [ ] `:spotifycore`
- [ ] Other:

## Screenshots / Recordings

| Before | After |
| --- | --- |
| *Discrete 12dp/32dp snap on gesture release* | *Continuous corner morphing during drag and route spring* |

## Behavior Notes

- **Swipe Down (Dismiss):** MiniPlayer bottom corners and NavBar top corners continuously morph from `12.dp` to `32.dp`. The morph completes at `74.dp` (`MiniPlayerHeight + MiniPlayerBottomSpacing`), exactly when MiniPlayer's top edge aligns flush with NavBar's top edge behind the toolbar.
- **Swipe Up (Expand):** Both components release their docked shape over the same symmetrical `74.dp` travel window as MiniPlayer lifts above the toolbar.
- **Route Transitions (Settings <-> Home):** The morph follows the navigation bar's animated height ratio (`navRatio`). A route-transition guard keyed on `COLLAPSED_ANCHOR` prevents layout-driven `collapsedBound` jumps from triggering false swipe deviations.
- **Recomposition Scope:** Proximity computation is wrapped in a stable `() -> Float` provider in `MainActivity`. State reads occur strictly at leaf composables (`NewMiniPlayer` and `FloatingNavigationToolbar`), allowing `bottomBar`, `BottomSheetPlayer`, and `HomeOverflowFab` to skip recomposition during drag frames.
- **Width Constraint:** `contentMaxWidth` retains its binary constraint behind `derivedStateOf { provider() > 0f }`, avoiding relayout thrashing during drag while preserving phone-width consistency.

## Architecture Checklist

- [x] The change preserves UDF flow: UI -> ViewModel -> UseCase/domain -> Repository/data.
- [ ] Screen state is represented structurally with `Loading`, `Success`, `Empty`, and `Error` where this PR introduces or changes screen state.
- [x] Composables receive immutable, UI-specific domain models instead of raw Room, network, or service entities.
- [x] Business work is not triggered directly from composition.
- [x] Exceptions are surfaced through explicit state or result types instead of being swallowed.
- [x] No `runBlocking` is introduced in app execution paths.

## Compose / Material Checklist

- [x] UI state is hoisted out of composable layout code.
- [x] Reactive state is collected with `collectAsStateWithLifecycle()`.
- [x] New UI models are annotated with `@Immutable` or `@Stable`.
- [ ] Lazy layouts use stable `key` values and explicit `contentType`.
- [x] Non-primitive constants, structural lambdas, and allocation-heavy objects in hot paths are remembered.
- [x] Rapidly changing inputs such as scroll, gesture, animation, or playback progress use `derivedStateOf` where appropriate.
- [x] UI strings come from `stringResource()` and duplicated visible strings on the same screen are avoided.
- [x] Interactive elements keep a minimum 48dp touch target.
- [x] Material 3 / Material 3 Expressive tokens are used for color, typography, shape, and motion instead of hardcoded UI values.
- [x] Edge-to-edge layouts handle and consume `WindowInsets` correctly when this PR changes screen layout.

## Concurrency / Performance Checklist

- [x] Business coroutines are scoped to `viewModelScope` or an existing lifecycle-owned application/service scope.
- [x] Disk, database, network, parsing, and heavy mapping work is dispatched to `Dispatchers.IO` or `Dispatchers.Default`.
- [x] Cancellation is handled explicitly where long-running work, playback, downloads, sync, lyrics fetching, or recognition is involved.
- [x] The change avoids blocking the main thread.
- [x] The change avoids unnecessary allocations in recomposition loops, playback loops, polling loops, and provider parsing paths.
- [x] Large lists, images, lyrics payloads, and network responses are bounded, streamed, cached, paged, or mapped off the main thread as appropriate.

## Data / Persistence Checklist

- [ ] Room entity, DAO, or database changes include a schema update under `app/schemas`.
- [ ] Database migrations preserve existing user data and fail clearly when migration is impossible.
- [ ] DataStore or preference-key changes are backward compatible.
- [ ] Network DTOs remain isolated from UI models.
- [ ] Provider responses handle missing, malformed, regional, or rate-limited data without crashing the app.

## Playback / Integration Checklist

- [x] Media3 playback, queue, cache, and service behavior remains stable across foreground, background, notification, and process recreation paths.
- [x] Audio focus, notification controls, widgets, shortcuts, and media session actions are considered when playback behavior changes.
- [x] External integrations handle absent credentials, revoked auth, network failure, and API changes.
- [x] Native, AAR, or ABI-sensitive changes account for mobile/tv and `universal`, `arm64`, `armeabi`, `x86`, and `x86_64` variants.

## Localization / Assets Checklist

- [ ] User-facing strings are added to the base resources and translated resources are updated or intentionally left for translation follow-up.
- [ ] Unused string resources, drawables, and metadata are removed when replaced.
- [ ] Image assets have explicit display dimensions and are decoded at the displayed size.
- [ ] Fastlane metadata, screenshots, icons, or release text are updated when user-facing store behavior changes.

## Privacy / Security Checklist

- [x] No secrets, keys, tokens, keystores, signing files, private certificates, or local machine paths are committed.
- [x] Logs do not expose access tokens, cookies, auth headers, user identifiers, listening history, or local file paths.
- [x] New network calls are justified by the feature and use existing client, proxy, timeout, and error-handling patterns.
- [x] User data remains local unless the PR explicitly documents the integration and consent path.

## Verification

- [x] Android Studio sync: Verified clean; all imports and references resolve without errors.
- [x] Manual device/emulator verification: Tested on physical 120Hz device across swipe-up, swipe-down dismiss, Home <-> Settings transitions, and playback rotation. Gfxinfo confirms 0 janky frame-deadline misses during active drag.
- [ ] UI screenshot/recording attached:
- [x] Accessibility or touch-target review: Touch target bounds and surface elevation remain fully compliant; touch hit-testing follows active shape geometry.
- [x] Regression areas checked: Full-screen player expand/collapse, queue opening, playback controls, bottom bar FAB positioning, and offline mode.
- [x] CI expectation: Clean build across all target flavors (FOSS and GMS universal/ABI variants).

## Reviewer Focus

- `MainActivity.kt`: `navigationProximityProvider` closure and `rememberUpdatedState` bindings ensuring non-stale reads during route switches.
- `MiniPlayer.kt` & `FloatingNavigationToolbar.kt`: Leaf-level consumption of proximity lambda with single-read per recomposition and `derivedStateOf` width gating.
- `Dimensions.kt`: Extraction of standalone (`32.dp`), outer (`28.dp`), and junction (`12.dp`) corner radius tokens.

## Release Notes

Smooth continuous shape morphing between the miniplayer and navigation bar during swipe gestures and screen transitions.