### PR TITLE
fix(ui): eliminate miniplayer fade and shape snap on route transitions

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -2131,8 +2131,6 @@ class MainActivity : ComponentActivity() {
                                 },
                                 bottomBar = {
                                     Box {
-                                        val showNavigationBarState = rememberUpdatedState(shouldShowNavigationBar)
-                                        val useRailState = rememberUpdatedState(useRail)
                                         val navigationProximityProvider: () -> Float =
                                             remember(playerBottomSheetState, bottomNavigationBarHeightState) {
                                                 {
@@ -2155,11 +2153,7 @@ class MainActivity : ComponentActivity() {
                                                             }
                                                         }
                                                     val sheetPresence = (1f - (swipeDeviation / morphThreshold)).coerceIn(0f, 1f)
-                                                    if (!showNavigationBarState.value || useRailState.value) {
-                                                        0f
-                                                    } else {
-                                                        navRatio * sheetPresence
-                                                    }
+                                                    navRatio * sheetPresence
                                                 }
                                             }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/BottomSheet.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/BottomSheet.kt
@@ -159,31 +159,51 @@ class BottomSheetState(
 ) : DraggableState by draggableState {
     private val collapsedBoundState = mutableStateOf(collapsedBound)
 
+    /**
+     * Effective collapsed bound currently applied to the sheet.
+     * During navigation bar transitions, this value animates per-frame to follow the bar smoothly.
+     */
     val collapsedBound: Dp
         get() = collapsedBoundState.value
 
-    var targetCollapsedBound: Dp by mutableStateOf(collapsedBound)
+    /**
+     * The destination collapsed bound for the current route.
+     */
+    internal var targetCollapsedBound: Dp by mutableStateOf(
+        collapsedBound.coerceIn(animatable.lowerBound!!, animatable.upperBound!!)
+    )
         private set
 
     private var lastAnimationSpec: AnimationSpec<Dp> =
         if (animationsDisabled) snap() else BottomSheetAnimationSpec
 
+    /**
+     * Updates the target collapsed bound when route or navigation bar presence changes.
+     * If the sheet is actively in-flight collapsing, retargets the animation to the new bound
+     * from its current position. In-flight collapses settle using [lastAnimationSpec], while
+     * any remaining difference is cleanly resolved per-frame by [reanchorTo].
+     */
     internal fun updateTargetCollapsedBound(newTargetBound: Dp) {
+        val clampedTarget = newTargetBound.coerceIn(animatable.lowerBound!!, animatable.upperBound!!)
         val previousTarget = targetCollapsedBound
-        targetCollapsedBound = newTargetBound
-        if (previousTarget == newTargetBound) return
+        targetCollapsedBound = clampedTarget
+        if (previousTarget == clampedTarget) return
 
         if (targetAnchor == COLLAPSED_ANCHOR) {
             val isRestingAtOldCollapsed = !animatable.isRunning &&
                 (animatable.value - collapsedBoundState.value).let { if (it < 0.dp) -it else it } < 0.5.dp
             if (!isRestingAtOldCollapsed) {
                 coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
-                    animatable.animateTo(newTargetBound, lastAnimationSpec)
+                    animatable.animateTo(clampedTarget, lastAnimationSpec)
                 }
             }
         }
     }
 
+    /**
+     * Shifts the resting sheet position and [collapsedBoundState] per-frame to match
+     * animated navigation bar changes without triggering full sheet recompositions.
+     */
     internal suspend fun reanchorTo(newCollapsedBound: Dp) {
         val previous = collapsedBoundState.value
         if (newCollapsedBound == previous) return

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/BottomSheet.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/BottomSheet.kt
@@ -13,6 +13,7 @@ import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.AnimationSpec
 import androidx.compose.animation.core.AnimationVector1D
 import androidx.compose.animation.core.VectorConverter
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.snap
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -31,15 +32,18 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
@@ -63,10 +67,14 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import moe.rukamori.archivetune.LocalAnimationsDisabled
 import moe.rukamori.archivetune.constants.BottomSheetAnimationSpec
 import moe.rukamori.archivetune.constants.BottomSheetSoftAnimationSpec
+import moe.rukamori.archivetune.constants.NavigationBarAnimationSpec
 
 /**
  * Bottom Sheet
@@ -146,9 +154,50 @@ class BottomSheetState(
     private val animatable: Animatable<Dp, AnimationVector1D>,
     private val onAnchorChanged: (Int) -> Unit,
     private val animationsDisabled: Boolean,
-    val collapsedBound: Dp,
+    collapsedBound: Dp,
     initialAnchor: Int = DISMISSED_ANCHOR,
 ) : DraggableState by draggableState {
+    private val collapsedBoundState = mutableStateOf(collapsedBound)
+
+    val collapsedBound: Dp
+        get() = collapsedBoundState.value
+
+    private var lastAnimationSpec: AnimationSpec<Dp> =
+        if (animationsDisabled) snap() else BottomSheetAnimationSpec
+
+    internal fun retargetCollapseIfNeeded(newTargetBound: Dp) {
+        if (targetAnchor == COLLAPSED_ANCHOR && animatable.isRunning && animatable.targetValue != newTargetBound) {
+            coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
+                animatable.animateTo(newTargetBound, lastAnimationSpec)
+            }
+        }
+    }
+
+    internal suspend fun reanchorTo(newCollapsedBound: Dp) {
+        val previous = collapsedBoundState.value
+        if (newCollapsedBound == previous) return
+        val current = animatable.value
+        val isRestingAtCollapsed = !animatable.isRunning &&
+            (current == previous || (current - previous).let { if (it < 0.dp) -it else it } < 0.5.dp)
+
+        val target =
+            if (isRestingAtCollapsed) {
+                newCollapsedBound.coerceIn(
+                    animatable.lowerBound!!,
+                    animatable.upperBound!!,
+                )
+            } else {
+                current
+            }
+
+        withContext(NonCancellable) {
+            if (target != current) {
+                animatable.snapTo(target)
+            }
+            collapsedBoundState.value = newCollapsedBound
+        }
+    }
+
     val dismissedBound: Dp
         get() = animatable.lowerBound!!
 
@@ -186,6 +235,7 @@ class BottomSheetState(
 
     fun collapse(animationSpec: AnimationSpec<Dp>) {
         updateAnchor(COLLAPSED_ANCHOR)
+        lastAnimationSpec = animationSpec
         coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
             animatable.animateTo(collapsedBound, animationSpec)
         }
@@ -193,6 +243,7 @@ class BottomSheetState(
 
     fun expand(animationSpec: AnimationSpec<Dp>) {
         updateAnchor(EXPANDED_ANCHOR)
+        lastAnimationSpec = animationSpec
         coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
             animatable.animateTo(animatable.upperBound!!, animationSpec)
         }
@@ -216,8 +267,10 @@ class BottomSheetState(
 
     fun dismiss() {
         updateAnchor(DISMISSED_ANCHOR)
+        val spec = if (animationsDisabled) snap() else BottomSheetAnimationSpec
+        lastAnimationSpec = spec
         coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
-            animatable.animateTo(animatable.lowerBound!!, if (animationsDisabled) snap() else BottomSheetAnimationSpec)
+            animatable.animateTo(animatable.lowerBound!!, spec)
         }
     }
 
@@ -360,35 +413,57 @@ fun rememberBottomSheetState(
             Animatable(0.dp, Dp.VectorConverter)
         }
 
-    return remember(dismissedBound, expandedBound, collapsedBound, coroutineScope, animationsDisabled) {
-        val initialValue =
-            when (previousAnchor) {
-                EXPANDED_ANCHOR -> expandedBound
-                COLLAPSED_ANCHOR -> collapsedBound
-                DISMISSED_ANCHOR -> dismissedBound
-                else -> error("Unknown BottomSheet anchor")
+    val state =
+        remember(dismissedBound, expandedBound, coroutineScope, animationsDisabled) {
+            val initialValue =
+                when (previousAnchor) {
+                    EXPANDED_ANCHOR -> expandedBound
+                    COLLAPSED_ANCHOR -> collapsedBound
+                    DISMISSED_ANCHOR -> dismissedBound
+                    else -> error("Unknown BottomSheet anchor")
+                }
+
+            animatable.updateBounds(dismissedBound.coerceAtMost(expandedBound), expandedBound)
+            coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
+                animatable.animateTo(initialValue, if (animationsDisabled) snap() else BottomSheetAnimationSpec)
             }
 
-        animatable.updateBounds(dismissedBound.coerceAtMost(expandedBound), expandedBound)
-        coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
-            animatable.animateTo(initialValue, if (animationsDisabled) snap() else BottomSheetAnimationSpec)
+            BottomSheetState(
+                draggableState =
+                    DraggableState { delta ->
+                        coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
+                            animatable.snapTo(animatable.value - with(density) { delta.toDp() })
+                        }
+                    },
+                onAnchorChanged = { previousAnchor = it },
+                coroutineScope = coroutineScope,
+                animatable = animatable,
+                animationsDisabled = animationsDisabled,
+                collapsedBound = collapsedBound,
+                initialAnchor = previousAnchor,
+            )
         }
 
-        BottomSheetState(
-            draggableState =
-                DraggableState { delta ->
-                    coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
-                        animatable.snapTo(animatable.value - with(density) { delta.toDp() })
-                    }
-                },
-            onAnchorChanged = { previousAnchor = it },
-            coroutineScope = coroutineScope,
-            animatable = animatable,
-            animationsDisabled = animationsDisabled,
-            collapsedBound = collapsedBound,
-            initialAnchor = previousAnchor,
-        )
+    // Retarget an in-flight collapse when the target collapsedBound changes (route change)
+    LaunchedEffect(state, collapsedBound) {
+        state.retargetCollapseIfNeeded(collapsedBound)
     }
+
+    // Re-anchor resting collapsed sheet frame-by-frame as the layout moves
+    val animationSpec = if (animationsDisabled) snap() else NavigationBarAnimationSpec
+    val animatedCollapsedBound by
+        animateDpAsState(
+            targetValue = collapsedBound,
+            animationSpec = animationSpec,
+            label = "SheetCollapsedBound",
+        )
+    LaunchedEffect(state) {
+        snapshotFlow { animatedCollapsedBound }.collect {
+            state.reanchorTo(it)
+        }
+    }
+
+    return state
 }
 
 private class BottomSheetGestureRegion(private val view: View) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/BottomSheet.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/BottomSheet.kt
@@ -159,16 +159,9 @@ class BottomSheetState(
 ) : DraggableState by draggableState {
     private val collapsedBoundState = mutableStateOf(collapsedBound)
 
-    /**
-     * Effective collapsed bound currently applied to the sheet.
-     * During navigation bar transitions, this value animates per-frame to follow the bar smoothly.
-     */
     val collapsedBound: Dp
         get() = collapsedBoundState.value
 
-    /**
-     * The destination collapsed bound for the current route.
-     */
     internal var targetCollapsedBound: Dp by mutableStateOf(
         collapsedBound.coerceIn(animatable.lowerBound!!, animatable.upperBound!!)
     )
@@ -177,12 +170,6 @@ class BottomSheetState(
     private var lastAnimationSpec: AnimationSpec<Dp> =
         if (animationsDisabled) snap() else BottomSheetAnimationSpec
 
-    /**
-     * Updates the target collapsed bound when route or navigation bar presence changes.
-     * If the sheet is actively in-flight collapsing, retargets the animation to the new bound
-     * from its current position. In-flight collapses settle using [lastAnimationSpec], while
-     * any remaining difference is cleanly resolved per-frame by [reanchorTo].
-     */
     internal fun updateTargetCollapsedBound(newTargetBound: Dp) {
         val clampedTarget = newTargetBound.coerceIn(animatable.lowerBound!!, animatable.upperBound!!)
         val previousTarget = targetCollapsedBound
@@ -200,10 +187,6 @@ class BottomSheetState(
         }
     }
 
-    /**
-     * Shifts the resting sheet position and [collapsedBoundState] per-frame to match
-     * animated navigation bar changes without triggering full sheet recompositions.
-     */
     internal suspend fun reanchorTo(newCollapsedBound: Dp) {
         val previous = collapsedBoundState.value
         if (newCollapsedBound == previous) return
@@ -475,12 +458,10 @@ fun rememberBottomSheetState(
             )
         }
 
-    // Update target bound and retarget an in-flight collapse when route changes
     LaunchedEffect(state, collapsedBound) {
         state.updateTargetCollapsedBound(collapsedBound)
     }
 
-    // Re-anchor resting collapsed sheet frame-by-frame as the layout moves
     val animationSpec = if (animationsDisabled) snap() else NavigationBarAnimationSpec
     val animatedCollapsedBound by
         animateDpAsState(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/BottomSheet.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/BottomSheet.kt
@@ -162,13 +162,24 @@ class BottomSheetState(
     val collapsedBound: Dp
         get() = collapsedBoundState.value
 
+    var targetCollapsedBound: Dp by mutableStateOf(collapsedBound)
+        private set
+
     private var lastAnimationSpec: AnimationSpec<Dp> =
         if (animationsDisabled) snap() else BottomSheetAnimationSpec
 
-    internal fun retargetCollapseIfNeeded(newTargetBound: Dp) {
-        if (targetAnchor == COLLAPSED_ANCHOR && animatable.isRunning && animatable.targetValue != newTargetBound) {
-            coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
-                animatable.animateTo(newTargetBound, lastAnimationSpec)
+    internal fun updateTargetCollapsedBound(newTargetBound: Dp) {
+        val previousTarget = targetCollapsedBound
+        targetCollapsedBound = newTargetBound
+        if (previousTarget == newTargetBound) return
+
+        if (targetAnchor == COLLAPSED_ANCHOR) {
+            val isRestingAtOldCollapsed = !animatable.isRunning &&
+                (animatable.value - collapsedBoundState.value).let { if (it < 0.dp) -it else it } < 0.5.dp
+            if (!isRestingAtOldCollapsed) {
+                coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
+                    animatable.animateTo(newTargetBound, lastAnimationSpec)
+                }
             }
         }
     }
@@ -237,7 +248,7 @@ class BottomSheetState(
         updateAnchor(COLLAPSED_ANCHOR)
         lastAnimationSpec = animationSpec
         coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
-            animatable.animateTo(collapsedBound, animationSpec)
+            animatable.animateTo(targetCollapsedBound, animationSpec)
         }
     }
 
@@ -444,9 +455,9 @@ fun rememberBottomSheetState(
             )
         }
 
-    // Retarget an in-flight collapse when the target collapsedBound changes (route change)
+    // Update target bound and retarget an in-flight collapse when route changes
     LaunchedEffect(state, collapsedBound) {
-        state.retargetCollapseIfNeeded(collapsedBound)
+        state.updateTargetCollapsedBound(collapsedBound)
     }
 
     // Re-anchor resting collapsed sheet frame-by-frame as the layout moves

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/PlayerMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/PlayerMenu.kt
@@ -613,7 +613,7 @@ fun PlayerMenu(
                                         text = stringResource(R.string.music_together),
                                         onClick = {
                                             onDismiss()
-                                            playerBottomSheetState.snapTo(playerBottomSheetState.collapsedBound)
+                                            playerBottomSheetState.collapseSoft()
                                             navController.navigate("settings/music_together")
                                         },
                                     ),
@@ -666,7 +666,7 @@ fun PlayerMenu(
                                     Modifier.clickable {
                                         if (splitArtists.size == 1 && splitArtists[0].originalArtist != null) {
                                             onDismiss()
-                                            playerBottomSheetState.snapTo(playerBottomSheetState.collapsedBound)
+                                            playerBottomSheetState.collapseSoft()
                                             navController.navigate("artist/${splitArtists[0].originalArtist!!.id}")
                                         } else {
                                             showSelectArtistDialog = true
@@ -695,7 +695,7 @@ fun PlayerMenu(
                                 modifier =
                                     Modifier.clickable {
                                         onDismiss()
-                                        playerBottomSheetState.snapTo(playerBottomSheetState.collapsedBound)
+                                        playerBottomSheetState.collapseSoft()
                                         navController.navigate("album/${mediaMetadata.album.id}")
                                     },
                                 colors = ListItemDefaults.colors(containerColor = Color.Transparent),


### PR DESCRIPTION
# Pull Request

Before submitting a pull request, you must attest to the following:

- [x] This pull request complies with ArchiveTune's [NO AI / NO LLM POLICY](../blob/main/CONTRIBUTING.md#no-ai--no-llm-policy).

## Summary

Fixes the miniplayer visual fade/flicker and shape desynchronization when navigating between routes with differing navigation bar visibilities (e.g., Home ↔ Settings). In `dev`, route switches recreated the entire `BottomSheetState` instance because `collapsedBound` was part of its `remember` keys, and `navigationProximityProvider` abruptly zeroed proximity via boolean flag checks before the navigation bar finished animating. This PR preserves the `BottomSheetState` instance across route switches, synchronizes resting sheets per-frame with the animated navigation bar height via `reanchorTo()`, retargets in-flight collapses to the destination bound, and replaces abrupt `snapTo()` calls in `PlayerMenu` with `collapseSoft()`.

## Linked Work

- Related: rukamori/ArchiveTune#1282

## Change Type

- [ ] Feature
- [x] Bug fix
- [x] UI / UX
- [ ] Performance / memory
- [ ] Playback / Media3
- [ ] Lyrics / provider integration
- [ ] Search / YouTube / network data
- [ ] Local library / Room database
- [ ] Widgets / notification / shortcuts
- [ ] Settings / preferences / DataStore
- [ ] Discord / Last.fm / ListenBrainz / external integration
- [ ] Localization / strings / fastlane metadata
- [ ] Build / Gradle / CI / release packaging
- [ ] Dependency update
- [ ] Documentation only

## Affected Surfaces

- [x] `:app`
- [ ] `:core`
- [ ] `:lyrics`
- [ ] `:lastfm`
- [ ] `:canvas`
- [ ] `:shazamkit`
- [ ] `:spotifycore`
- [ ] Other:

## Screenshots / Recordings

| Before | After |
| --- | --- |
| • Miniplayer flickers / fades out and in when navigating between screens that show or hide the navigation bar (e.g. Home ↔ Settings).<br>• Bottom corners snap abruptly into a standalone pill shape before the navigation bar finishes descending.<br>• Navigating to artist, album, or Music Together from the player menu instantly teleports (`snapTo`) the player sheet down with no animation. | • Miniplayer remains fully solid and visible with zero flicker during screen transitions.<br>• Bottom corners morph smoothly in continuous lockstep with the navigation bar animation.<br>• Navigating from the player menu smoothly animates the sheet down (`collapseSoft`) into the destination screen. |

## Behavior Notes

- **Route navigation (Home ↔ Settings / sub-screens)**: The miniplayer stays completely opaque and solid throughout screen transitions without recomposition flicker. Corner radii smoothly morph in lockstep with the entering or exiting navigation bar.
- **PlayerMenu navigation**: Navigating to an artist, album, or Music Together from `PlayerMenu` smoothly animates the sheet down via `collapseSoft()` rather than instantly jumping via `snapTo()`.
- **In-flight collapse handling**: If a collapse animation is active during a route change, the sheet smoothly retargets its trajectory toward the destination bound.
- **Animations disabled / TV / Rail**: Fallbacks honor `snap()` when animations are disabled, and non-mobile layouts continue to function with appropriate static bounds.

## Architecture Checklist

- [x] The change preserves UDF flow: UI -> ViewModel -> UseCase/domain -> Repository/data.
- [ ] Screen state is represented structurally with `Loading`, `Success`, `Empty`, and `Error` where this PR introduces or changes screen state.
- [x] Composables receive immutable, UI-specific domain models instead of raw Room, network, or service entities.
- [x] Business work is not triggered directly from composition.
- [x] Exceptions are surfaced through explicit state or result types instead of being swallowed.
- [x] No `runBlocking` is introduced in app execution paths.

## Compose / Material Checklist

- [x] UI state is hoisted out of composable layout code.
- [x] Reactive state is collected with `collectAsStateWithLifecycle()`.
- [x] New UI models are annotated with `@Immutable` or `@Stable`.
- [x] Lazy layouts use stable `key` values and explicit `contentType`.
- [x] Non-primitive constants, structural lambdas, and allocation-heavy objects in hot paths are remembered.
- [x] Rapidly changing inputs such as scroll, gesture, animation, or playback progress use `derivedStateOf` where appropriate.
- [x] UI strings come from `stringResource()` and duplicated visible strings on the same screen are avoided.
- [x] Interactive elements keep a minimum 48dp touch target.
- [x] Material 3 / Material 3 Expressive tokens are used for color, typography, shape, and motion instead of hardcoded UI values.
- [x] Edge-to-edge layouts handle and consume `WindowInsets` correctly when this PR changes screen layout.

## Concurrency / Performance Checklist

- [x] Business coroutines are scoped to `viewModelScope` or an existing lifecycle-owned application/service scope.
- [x] Disk, database, network, parsing, and heavy mapping work is dispatched to `Dispatchers.IO` or `Dispatchers.Default`.
- [x] Cancellation is handled explicitly where long-running work, playback, downloads, sync, lyrics fetching, or recognition is involved.
- [x] The change avoids blocking the main thread.
- [x] The change avoids unnecessary allocations in recomposition loops, playback loops, polling loops, and provider parsing paths.
- [x] Large lists, images, lyrics payloads, and network responses are bounded, streamed, cached, paged, or mapped off the main thread as appropriate.

## Data / Persistence Checklist

- [ ] Room entity, DAO, or database changes include a schema update under `app/schemas`.
- [ ] Database migrations preserve existing user data and fail clearly when migration is impossible.
- [ ] DataStore or preference-key changes are backward compatible.
- [ ] Network DTOs remain isolated from UI models.
- [ ] Provider responses handle missing, malformed, regional, or rate-limited data without crashing the app.

## Playback / Integration Checklist

- [x] Media3 playback, queue, cache, and service behavior remains stable across foreground, background, notification, and process recreation paths.
- [x] Audio focus, notification controls, widgets, shortcuts, and media session actions are considered when playback behavior changes.
- [x] External integrations handle absent credentials, revoked auth, network failure, and API changes.
- [x] Native, AAR, or ABI-sensitive changes account for mobile/tv and `universal`, `arm64`, `armeabi`, `x86`, and `x86_64` variants.

## Localization / Assets Checklist

- [ ] User-facing strings are added to the base resources and translated resources are updated or intentionally left for translation follow-up.
- [ ] Unused string resources, drawables, and metadata are removed when replaced.
- [ ] Image assets have explicit display dimensions and are decoded at the displayed size.
- [ ] Fastlane metadata, screenshots, icons, or release text are updated when user-facing store behavior changes.

## Privacy / Security Checklist

- [x] No secrets, keys, tokens, keystores, signing files, private certificates, or local machine paths are committed.
- [x] Logs do not expose access tokens, cookies, auth headers, user identifiers, listening history, or local file paths.
- [x] New network calls are justified by the feature and use existing client, proxy, timeout, and error-handling patterns.
- [x] User data remains local unless the PR explicitly documents the integration and consent path.

## Verification

- [x] Android Studio sync: Verified clean; all imports and references resolve without errors.
- [x] Manual device/emulator verification: Tested on physical device across Home ↔ Settings transitions, sub-screen navigation, PlayerMenu album/artist actions, rapid route switching, and swipe gestures.
- [ ] UI screenshot/recording attached:
- [x] Accessibility or touch-target review: Touch targets and gestures remain intact; sheet re-anchoring does not interrupt gesture hit-testing.
- [x] Regression areas checked: Full-screen player expand/collapse, queue opening/closing, player menu navigation, dismissed player state across route transitions.
- [x] CI expectation: Clean build across all target flavors.

## Reviewer Focus

- `BottomSheet.kt`: Removal of `collapsedBound` from `remember` keys to avoid destroying/recreating `BottomSheetState` on route switches; `reanchorTo` frame-by-frame synchronization for resting sheets; `updateTargetCollapsedBound` retargeting logic for in-flight collapses; bound clamping and internal visibility.
- `MainActivity.kt`: Removal of boolean short-circuit (`!shouldShowNavigationBar || useRail`) from `navigationProximityProvider` so shape morphing is driven purely and continuously by animated navigation bar height.
- `PlayerMenu.kt`: Replacing abrupt `snapTo()` calls with `collapseSoft()` on navigation click handlers.

## Release Notes

Fix miniplayer flickering and premature corner shape snapping when navigating to screens without a navigation bar.